### PR TITLE
Modernize global Claude Code setup with permissions, hooks, and skills

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -1,6 +1,17 @@
-- use `exa -la` instead of `ls -la`
-- use a functional programing paradigm
-- Always read documentation in the @.claude directory, read all documentation in the project, and study the directory structure
-- use git switch -c to create a new branch. use git switch to change branch
-- always use uv to run python, not global python
-- Use the existing shell and uv when running python scripts.
+# Global Conventions
+
+## Shell & Tooling
+- IMPORTANT: Use `eza -la` for directory listings, never bare `ls`
+- IMPORTANT: Use `uv run` for all Python execution, never global python or pip
+- Use `git switch -c <branch>` to create branches, `git switch <branch>` to change
+- This is Arch Linux with zsh
+
+## Code Style
+- YOU MUST follow a functional programming paradigm: pure functions, immutable data, composition over inheritance, map/filter/reduce over loops
+- Prefer type annotations in Python. Use `ruff` for linting when available.
+- In Rust, prefer iterators and combinators over manual loops
+
+## Workflow
+- Run tests before committing. Verify changes compile/pass before marking done.
+- Commit messages: imperative mood, concise first line (<72 chars)
+- Never commit .env files, credentials, or API keys

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -1,4 +1,6 @@
 - use `exa -la` instead of `ls -la`
 - use a functional programing paradigm
-- Always read documentation in the @.claude directory, read all documentation in the project, and study the directory structure 
+- Always read documentation in the @.claude directory, read all documentation in the project, and study the directory structure
 - use git switch -c to create a new branch. use git switch to change branch
+- always use uv to run python, not global python
+- Use the existing shell and uv when running python scripts.

--- a/claude/hooks/block-sensitive-files.sh
+++ b/claude/hooks/block-sensitive-files.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+INPUT=$(cat)
+FILE=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+
+case "$FILE" in
+  *.env|*.env.*|*credentials*|*secret*|*.pem|*.key)
+    echo "BLOCKED: refusing to modify sensitive file: $FILE" >&2
+    exit 2
+    ;;
+esac
+
+exit 0

--- a/claude/hooks/notify-stop.sh
+++ b/claude/hooks/notify-stop.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+notify-send --urgency=normal --icon=dialog-information "Claude Code" "Task completed"
+exit 0

--- a/claude/hooks/notify.sh
+++ b/claude/hooks/notify.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+INPUT=$(cat)
+MESSAGE=$(echo "$INPUT" | jq -r '.message // "Attention needed"')
+notify-send --urgency=normal --icon=dialog-information "Claude Code" "$MESSAGE"
+exit 0

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -1,20 +1,74 @@
 {
-  "feedbackSurveyState": {
-    "lastShownTime": 1754090505960
-  },
-  "mcpServers": {
-    "ducklake": {
-      "command": "mcp-server-ducklake",
-      "args": [
-        "--env-file",
-        "/home/anotherjson/Workspace/steffy_fantasy_football/.env"
-      ],
-      "cwd": "/home/anotherjson/Workspace/steffy_fantasy_football"
-    }
-  },
   "effortLevel": "high",
   "statusLine": {
     "type": "command",
     "command": "bash /home/anotherjson/.claude/statusline-command.sh"
-  }
+  },
+  "env": {
+    "UV_PYTHON_PREFERENCE": "only-managed"
+  },
+  "permissions": {
+    "allow": [
+      "Bash(git *)",
+      "Bash(eza *)",
+      "Bash(exa *)",
+      "Bash(uv *)",
+      "Bash(cargo *)",
+      "Bash(ruff *)",
+      "Bash(pytest *)",
+      "Bash(gh *)",
+      "Bash(jq *)",
+      "Bash(just *)",
+      "Bash(npm *)",
+      "Bash(npx *)",
+      "Bash(node *)",
+      "Bash(pnpm *)",
+      "Read",
+      "Glob",
+      "Grep",
+      "WebFetch",
+      "WebSearch"
+    ],
+    "deny": [
+      "Bash(rm -rf /)",
+      "Bash(sudo rm *)",
+      "Bash(chmod 777 *)",
+      "Bash(curl * | bash)",
+      "Bash(wget * | bash)"
+    ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash /home/anotherjson/.claude/hooks/block-sensitive-files.sh"
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash /home/anotherjson/.claude/hooks/notify.sh"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash /home/anotherjson/.claude/hooks/notify-stop.sh"
+          }
+        ]
+      }
+    ]
+  },
+  "mcpServers": {}
 }

--- a/claude/skills/commit/SKILL.md
+++ b/claude/skills/commit/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: commit
+description: Create a well-structured git commit with conventional format
+allowed-tools: ["Bash", "Read", "Grep"]
+user-invocable: true
+disable-model-invocation: true
+model: haiku
+---
+
+Create a git commit for the current changes.
+
+Steps:
+1. Run `git status` and `git diff --staged` (or `git diff` if nothing staged)
+2. Analyze changes to determine type: feat, fix, refactor, docs, test, chore
+3. Draft a conventional commit message: `type(scope): description`
+4. Stage relevant files if needed (never stage .env, credentials, or secrets)
+5. Show the proposed message and ask for confirmation
+6. Commit with the approved message
+
+$ARGUMENTS is an optional hint about what the commit is for.

--- a/claude/skills/pr/SKILL.md
+++ b/claude/skills/pr/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: pr
+description: Create a GitHub PR with auto-generated summary from branch commits
+allowed-tools: ["Bash", "Read", "Grep"]
+user-invocable: true
+disable-model-invocation: true
+model: haiku
+---
+
+Create a GitHub pull request for the current branch.
+
+Steps:
+1. Determine the base branch (usually main)
+2. Run `git log main..HEAD --oneline` to see all commits
+3. Run `git diff main...HEAD --stat` for changed files summary
+4. Draft a PR title (<70 chars) and body with:
+   - ## Summary (2-3 bullet points)
+   - ## Changes (file-level summary)
+   - ## Test plan (checklist)
+5. Push the branch with `git push -u origin HEAD` if needed
+6. Create the PR with `gh pr create`
+7. Return the PR URL
+
+$ARGUMENTS can specify the base branch or title hint.

--- a/claude/skills/research/SKILL.md
+++ b/claude/skills/research/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: research
+description: Research a topic online and summarize findings
+allowed-tools: ["WebSearch", "WebFetch", "Read", "Write"]
+user-invocable: true
+disable-model-invocation: true
+model: sonnet
+---
+
+Research a topic thoroughly using web search and present organized findings.
+
+Steps:
+1. Break $ARGUMENTS into 2-3 targeted search queries
+2. Search the web for each query
+3. Fetch and read the most relevant results (up to 5 sources)
+4. Synthesize findings into a structured summary with:
+   - Key findings
+   - Comparison of approaches (if applicable)
+   - Recommended approach with rationale
+   - Source links
+
+Prefer official documentation and recent sources (2025-2026). Cross-reference claims across multiple sources.

--- a/claude/skills/review/SKILL.md
+++ b/claude/skills/review/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: review
+description: Review staged changes or a PR for bugs, style, and improvements
+allowed-tools: ["Bash", "Read", "Grep", "Glob"]
+user-invocable: true
+disable-model-invocation: true
+model: sonnet
+---
+
+Perform a thorough code review.
+
+If $ARGUMENTS is a PR number or URL, review that PR using `gh pr diff`.
+Otherwise, review the current staged changes or working tree diff.
+
+Review criteria:
+1. **Correctness**: Logic errors, edge cases, off-by-one, null/None handling
+2. **Security**: Credential exposure, injection, unsafe deserialization
+3. **Style**: Functional patterns, naming, DRY, readability
+4. **Performance**: Unnecessary allocations, N+1 queries, blocking calls
+5. **Tests**: Are changes tested? Are tests meaningful?
+
+Output format:
+- Group findings by severity: CRITICAL, IMPORTANT, SUGGESTION
+- Reference specific file:line_number
+- Provide concrete fix suggestions
+- End with a brief overall assessment

--- a/claude/skills/uv-init/SKILL.md
+++ b/claude/skills/uv-init/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: uv-init
+description: Bootstrap a new Python project with uv, ruff, pytest
+allowed-tools: ["Bash", "Write", "Read"]
+user-invocable: true
+disable-model-invocation: true
+model: haiku
+---
+
+Bootstrap a new Python project with modern tooling.
+
+Steps:
+1. Run `uv init $ARGUMENTS` (project name from arguments, or ask)
+2. Add dev dependencies: `uv add --dev ruff pytest mypy`
+3. Configure pyproject.toml with ruff rules and pytest config
+4. Create src layout with __init__.py
+5. Create tests/ directory with conftest.py
+6. Create .gitignore if not present
+7. Initialize git repo if not already one
+8. Print summary of created structure
+
+Follow functional programming conventions: pure functions, type hints, no classes unless necessary.

--- a/gemini/.gemini/GEMINI.md
+++ b/gemini/.gemini/GEMINI.md
@@ -2,3 +2,6 @@
 
 - always use uv to run python, not global python
 - Use the existing shell and uv when running python scripts.
+- use `exa -la` instead of `ls -la`
+- use a functional programing paradigm
+- use git switch -c to create a new branch. use git switch to change branch

--- a/gemini/.gemini/GEMINI.md
+++ b/gemini/.gemini/GEMINI.md
@@ -1,17 +1,20 @@
 ## My Primary Goal
 
-I am a software developer. My primary goal is to get help with my personal software projects.
+I am a software developer. My primary goal is to get help with my personal software projects, focusing on my preferred technology stack.
 
 ## Core Tenets
 
-- **Functional Programming:** Always prefer a functional programming paradigm.
-- **`uv` for Python:** Always use `uv` to run python, not the global python interpreter. Use the existing shell and `uv` when running python scripts.
+- **Python via `uv`:** All Python-related tasks, including running scripts, managing dependencies, and setting up environments, MUST be done using the `uv` command.
+- **Frontend Stack:** The primary frontend stack is Svelte/SvelteKit with TypeScript and Tailwind CSS. Tooling like `svelte-check`, `vitest`, and `eslint` should be used.
+- **Backend Stack:** The preferred backend language is Rust. The standard Rust toolchain (`cargo`, `rustfmt`, `clippy`) is expected.
+- **Testing is Mandatory:** All new code or changes must be accompanied by relevant tests using the designated frameworks (`pytest` for Python, `vitest` for Svelte/TS, `cargo test` for Rust).
+- **Functional Programming:** Always prefer a functional programming paradigm where it makes sense.
 
 ## Persona
 
-You are an expert polyglot software architect. You are a master of all programming languages and paradigms, and you are able to quickly understand and contribute to any software project.
+You are an expert polyglot software architect with deep specialization in Rust, Python (using `uv`), and modern frontend frameworks like SvelteKit with TypeScript and Tailwind CSS. You are a master of these tools and their ecosystems, and you are able to quickly understand and contribute to any software project using them.
 
 ## Aliases & Preferences
 
-- **`ls`:** Always use `exa -la` instead of `ls -la`.
+- **`ls`:** Always use `eza -la` instead of `ls`.
 - **`git`:** Use `git switch -c` to create a new branch, and `git switch` to change branches.

--- a/gemini/.gemini/GEMINI.md
+++ b/gemini/.gemini/GEMINI.md
@@ -1,7 +1,17 @@
-## Gemini Added Memories
+## My Primary Goal
 
-- always use uv to run python, not global python
-- Use the existing shell and uv when running python scripts.
-- use `exa -la` instead of `ls -la`
-- use a functional programing paradigm
-- use git switch -c to create a new branch. use git switch to change branch
+I am a software developer. My primary goal is to get help with my personal software projects.
+
+## Core Tenets
+
+- **Functional Programming:** Always prefer a functional programming paradigm.
+- **`uv` for Python:** Always use `uv` to run python, not the global python interpreter. Use the existing shell and `uv` when running python scripts.
+
+## Persona
+
+You are an expert polyglot software architect. You are a master of all programming languages and paradigms, and you are able to quickly understand and contribute to any software project.
+
+## Aliases & Preferences
+
+- **`ls`:** Always use `exa -la` instead of `ls -la`.
+- **`git`:** Use `git switch -c` to create a new branch, and `git switch` to change branches.

--- a/gemini/.gemini/agents/software-architect.md
+++ b/gemini/.gemini/agents/software-architect.md
@@ -1,0 +1,14 @@
+# Agent: Software Architect
+
+## Persona
+
+You are an expert polyglot software architect. You are a master of all programming languages and paradigms, and you are able to quickly understand and contribute to any software project. You have a deep understanding of software design patterns, and you are able to design and implement scalable, maintainable, and testable software systems.
+
+## Instructions
+
+-   When this persona is active, your primary focus is on high-level design and architecture.
+-   You should ask clarifying questions to understand the requirements before proposing a solution.
+-   You should provide clear and concise explanations of your design decisions.
+-   You should use diagrams (e.g., using mermaid syntax) to illustrate your architecture when appropriate.
+-   You should provide code examples to illustrate your design patterns.
+-   You should always consider the long-term maintainability and scalability of the system.

--- a/gemini/.gemini/agents/software-architect.md
+++ b/gemini/.gemini/agents/software-architect.md
@@ -2,13 +2,15 @@
 
 ## Persona
 
-You are an expert polyglot software architect. You are a master of all programming languages and paradigms, and you are able to quickly understand and contribute to any software project. You have a deep understanding of software design patterns, and you are able to design and implement scalable, maintainable, and testable software systems.
+You are an expert polyglot software architect with deep specialization in Rust, Python (using `uv`), and modern frontend frameworks like SvelteKit with TypeScript and Tailwind CSS. You are a master of these tools and their ecosystems, and you are able to quickly understand and contribute to any software project using them.
 
 ## Instructions
 
--   When this persona is active, your primary focus is on high-level design and architecture.
--   You should ask clarifying questions to understand the requirements before proposing a solution.
--   You should provide clear and concise explanations of your design decisions.
--   You should use diagrams (e.g., using mermaid syntax) to illustrate your architecture when appropriate.
--   You should provide code examples to illustrate your design patterns.
--   You should always consider the long-term maintainability and scalability of the system.
+-   When this persona is active, your primary focus is on high-level design and architecture using your specialized stack.
+-   When proposing solutions, default to the user's preferred technologies: SvelteKit for frontend, Rust for backend, and `uv` for all Python tasks.
+-   Ask clarifying questions to understand the requirements before proposing a solution.
+-   Provide clear and concise explanations of your design decisions.
+-   Use diagrams (e.g., using mermaid syntax) to illustrate your architecture when appropriate.
+-   Provide code examples in TypeScript, Rust, or Python to illustrate your design patterns.
+-   Always consider the long-term maintainability, testability, and scalability of the system within the context of the user's stack.
+-   Adhere to the testing requirements: `pytest` for Python, `vitest` for Svelte/TS, `cargo test` for Rust.

--- a/gemini/.gemini/skills/component-creator/SKILL.md
+++ b/gemini/.gemini/skills/component-creator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: component-creator
-description: A skill to create boilerplate code for new software components.
+description: A skill to create boilerplate code for new Svelte, Python, or Rust components.
 ---
 # Skill: Component Creator
 
@@ -8,10 +8,11 @@ description: A skill to create boilerplate code for new software components.
 
 1.  **Ask for details:** Ask the user for the following information:
     -   The name of the component (e.g., `MyComponent`, `user_service`).
-    -   The programming language (e.g., `JavaScript`, `Python`, `TypeScript`).
+    -   The programming language (e.g., `Svelte`, `Python`, `Rust`).
     -   The directory where the component should be created.
 2.  **Generate boilerplate:** Based on the language, generate a basic boilerplate file.
-    -   For **JavaScript/TypeScript**, create a React component.
-    -   For **Python**, create a simple class.
-3.  **Create the file:** Create a new file with the appropriate extension (e.g., `.js`, `.py`, `.tsx`) in the specified directory.
+    -   For **Svelte**, create a Svelte component (`.svelte` file) with a `<script lang="ts">` block and basic Tailwind CSS classes.
+    -   For **Python**, create a simple class, remembering to use modern type hints.
+    -   For **Rust**, create a new file with a public struct or function.
+3.  **Create the file:** Create a new file with the appropriate name and extension (e.g., `MyComponent.svelte`, `user_service.py`, `my_module.rs`) in the specified directory.
 4.  **Inform the user:** Let the user know that the component has been created, and show them the path to the new file.

--- a/gemini/.gemini/skills/component-creator/SKILL.md
+++ b/gemini/.gemini/skills/component-creator/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: component-creator
+description: A skill to create boilerplate code for new software components.
+---
+# Skill: Component Creator
+
+## Instructions
+
+1.  **Ask for details:** Ask the user for the following information:
+    -   The name of the component (e.g., `MyComponent`, `user_service`).
+    -   The programming language (e.g., `JavaScript`, `Python`, `TypeScript`).
+    -   The directory where the component should be created.
+2.  **Generate boilerplate:** Based on the language, generate a basic boilerplate file.
+    -   For **JavaScript/TypeScript**, create a React component.
+    -   For **Python**, create a simple class.
+3.  **Create the file:** Create a new file with the appropriate extension (e.g., `.js`, `.py`, `.tsx`) in the specified directory.
+4.  **Inform the user:** Let the user know that the component has been created, and show them the path to the new file.

--- a/justfile
+++ b/justfile
@@ -7,12 +7,14 @@ claude_repo := dotfiles / "claude"
 
 # Copy repo configs → ~/.claude/
 claude-deploy:
-    @mkdir -p "{{claude_live}}/agents"
+    @mkdir -p "{{claude_live}}/agents" "{{claude_live}}/hooks" "{{claude_live}}/skills"
     @cp "{{claude_repo}}/CLAUDE.md" "{{claude_live}}/CLAUDE.md"
     @cp "{{claude_repo}}/settings.json" "{{claude_live}}/settings.json"
     @cp "{{claude_repo}}/settings.local.json" "{{claude_live}}/settings.local.json"
     @cp "{{claude_repo}}/statusline-command.sh" "{{claude_live}}/statusline-command.sh"
     @cp "{{claude_repo}}"/agents/*.md "{{claude_live}}/agents/"
+    @cp "{{claude_repo}}"/hooks/*.sh "{{claude_live}}/hooks/"
+    @cp -r "{{claude_repo}}"/skills/* "{{claude_live}}/skills/"
     @echo "claude config deployed to ~/.claude/"
 
 # Copy ~/.claude/ configs → repo
@@ -22,6 +24,8 @@ claude-pull:
     @test -f "{{claude_live}}/settings.local.json" && cp "{{claude_live}}/settings.local.json" "{{claude_repo}}/settings.local.json" || true
     @cp "{{claude_live}}/statusline-command.sh" "{{claude_repo}}/statusline-command.sh"
     @cp "{{claude_live}}"/agents/*.md "{{claude_repo}}/agents/"
+    @test -d "{{claude_live}}/hooks" && cp "{{claude_live}}"/hooks/*.sh "{{claude_repo}}/hooks/" || true
+    @test -d "{{claude_live}}/skills" && cp -r "{{claude_live}}"/skills/* "{{claude_repo}}/skills/" || true
     @echo "claude config pulled into repo"
 
 # Show full diff between repo and live configs
@@ -31,6 +35,8 @@ claude-diff:
     @diff -ru "{{claude_repo}}/settings.local.json" "{{claude_live}}/settings.local.json" 2>/dev/null || true
     @diff -ru "{{claude_repo}}/statusline-command.sh" "{{claude_live}}/statusline-command.sh" || true
     @diff -ru "{{claude_repo}}/agents" "{{claude_live}}/agents" || true
+    @diff -ru "{{claude_repo}}/hooks" "{{claude_live}}/hooks" 2>/dev/null || true
+    @diff -ru "{{claude_repo}}/skills" "{{claude_live}}/skills" 2>/dev/null || true
 
 # Quick summary of what differs
 claude-status:
@@ -43,9 +49,19 @@ claude-status:
             echo "repo only: $f"; changed=1
         fi
     done
-    agent_diff=$(diff -rq "{{claude_repo}}/agents" "{{claude_live}}/agents"  2>/dev/null) || true
+    agent_diff=$(diff -rq "{{claude_repo}}/agents" "{{claude_live}}/agents" 2>/dev/null) || true
     if [ -n "$agent_diff" ]; then
         echo "$agent_diff" | while read -r line; do echo "changed: agents/ — $line"; done
+        changed=1
+    fi
+    hooks_diff=$(diff -rq "{{claude_repo}}/hooks" "{{claude_live}}/hooks" 2>/dev/null) || true
+    if [ -n "$hooks_diff" ]; then
+        echo "$hooks_diff" | while read -r line; do echo "changed: hooks/ — $line"; done
+        changed=1
+    fi
+    skills_diff=$(diff -rq "{{claude_repo}}/skills" "{{claude_live}}/skills" 2>/dev/null) || true
+    if [ -n "$skills_diff" ]; then
+        echo "$skills_diff" | while read -r line; do echo "changed: skills/ — $line"; done
         changed=1
     fi
     [ "$changed" -eq 0 ] && echo "in sync" || true


### PR DESCRIPTION
## Summary

- Added permission allow/deny lists to eliminate constant permission prompts for safe commands (git, uv, cargo, ruff, pytest, gh, etc.)
- Created 3 pre-built hooks for sensitive file protection, desktop notifications, and task completion
- Added 5 user-invocable skills for common workflows: /commit (conventional commit), /pr (PR creation), /review (code review), /uv-init (Python bootstrap), /research (web research)
- Modernized CLAUDE.md with higher-signal guidance: eza support, Rust conventions, functional programming mandate
- Updated justfile to sync hooks/ and skills/ directories alongside existing agents/

## Changes

- **claude/CLAUDE.md** — Rewritten with emphasis markers and higher-signal content
- **claude/settings.json** — Added permissions, hooks, env (UV_PYTHON_PREFERENCE); removed ducklake MCP and feedbackSurveyState
- **claude/hooks/** — 3 new bash scripts for PreToolUse, Notification, and Stop events
- **claude/skills/** — 5 new SKILL.md definitions with model routing (haiku for simple tasks, sonnet for complex)
- **justfile** — Extended claude-deploy, claude-pull, claude-diff, claude-status recipes to handle hooks/ and skills/
- **gemini/.gemini/** — Updated GEMINI.md with clearer structure; added software-architect agent and component-creator skill

## Test plan

- [x] Deploy configs with `just claude-deploy`
- [x] Verify `just claude-status` reports "in sync"
- [x] Restart Claude Code and confirm /commit, /pr, /review, /uv-init, /research appear in slash menu
- [x] Verify hooks execute without errors (notify-send fires on task completion)
- [x] Verify permissions work: run `git status` without permission prompt
- [x] Verify CLAUDE.md content is loaded correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)