### PR TITLE
feat(photo-workstream): setup darktable and automount SD cards via udiskie

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -272,6 +272,7 @@ tags
 [Ll]ocal
 [Ss]cripts
 !hypr/.config/hypr/scripts/
+!waybar/.config/waybar/scripts/
 pyvenv.cfg
 pip-selfcheck.json
 

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -3,6 +3,7 @@
 ## Shell & Tooling
 - IMPORTANT: Use `eza -la` for directory listings, never bare `ls`
 - IMPORTANT: Use `uv run` for all Python execution, never global python or pip
+- IMPORTANT: Use `yay` for **all** package operations — install, remove, query, search, file-owns. Never bare `pacman`, not even for read-only queries like `-Q` / `-Si` / `-F`. yay accepts the same flags and wraps pacman. Use `sudo pacman` only if explicitly asked.
 - Use `git switch -c <branch>` to create branches, `git switch <branch>` to change
 - This is Arch Linux with zsh
 

--- a/hypr/.config/hypr/hyprland.conf
+++ b/hypr/.config/hypr/hyprland.conf
@@ -44,6 +44,7 @@ $idle = hypridle
 $bar = waybar
 $paper = hyprpaper
 $noti = notify-send
+$diskmanager = udiskie
 
 
 #################
@@ -56,7 +57,7 @@ $noti = notify-send
 # exec-once = $terminal
 # exec-once = nm-applet &
 # exec-once = waybar & hyprpaper & firefox
-exec-once = $bar & $menu & $idle & $paper
+exec-once = $bar & $menu & $idle & $paper & $diskmanager
 # exec-once=dbus-update-activation-environment --systemd WAYLAND_DISPLAY XDG_CURRENT_DESKTOP
 exec = gsettings set org.gnome.desktop.interface gtk-theme 'adw-gtk3-dark'
 exec = gsettings set org.gnome.desktop.interface color-scheme 'prefer-dark'
@@ -184,7 +185,7 @@ animations {
 
 # See https://wiki.hyprland.org/Configuring/Dwindle-Layout/ for more
 dwindle {
-    pseudotile = true # Master switch for pseudotiling. Enabling is bound to mainMod + P in the keybinds section below
+    # pseudotile removed in Hyprland 0.55; per-window pseudo via the `pseudo` dispatcher (see Super+P bind below)
     preserve_split = true # You probably want this
 }
 
@@ -253,7 +254,7 @@ bind = $mainMod, f, exec, $fileManager
 bind = $mainMod, ', togglefloating,
 bind = $mainMod, space, exec, $menu
 bind = $mainMod, p, pseudo, # dwindle
-bind = $mainMod, s, togglesplit, # dwindle
+bind = $mainMod, s, layoutmsg, togglesplit # dwindle (0.54+ requires layoutmsg)
 bind = $mainMod, w, exec, $screenshot -m window # hyprshot
 bind = $mainMod, m, exec, $screenshot -m output # hyprshot
 bind = $mainMod, r, exec, $screenshot -m region # hyprshot

--- a/justfile
+++ b/justfile
@@ -117,7 +117,7 @@ _pkgs := "hyprland hyprlock hypridle hyprpaper xdg-desktop-portal-hyprland " + \
          "jq curl " + \
          "adw-gtk-theme ttf-firacode-nerd " + \
          "stow just git " + \
-         "udiskie exfatprogs " + \
+         "udiskie exfatprogs nautilus " + \
          "darktable " + \
          "opencode"
 

--- a/justfile
+++ b/justfile
@@ -112,11 +112,13 @@ deploy-all: stow-all claude-deploy firefox-deploy
 _pkgs := "hyprland hyprlock hypridle hyprpaper xdg-desktop-portal-hyprland " + \
          "waybar wofi swaync " + \
          "pipewire wireplumber pavucontrol libnotify " + \
-         "kitty wezterm neovim zsh starship " + \
+         "kitty wezterm-git neovim zsh starship " + \
          "brightnessctl playerctl hyprshot " + \
          "jq curl " + \
          "adw-gtk-theme ttf-firacode-nerd " + \
          "stow just git " + \
+         "udiskie exfatprogs " + \
+         "darktable " + \
          "opencode"
 
 # Print the package list, one per line (used by CI to validate names)
@@ -135,3 +137,4 @@ bootstrap: install-deps deploy-all
     @echo '  2. Reload Hyprland (Super+Shift+C) to apply config'
     @echo '  3. Log out and back in once for GTK theme to fully apply'
     @echo '  4. Open a new shell so .zshrc loads (dots alias becomes available)'
+    @echo '  5. sudo systemctl enable --now udisks2     # enable removable-media automount for udiskie'

--- a/udiskie/.config/udiskie/config.yml
+++ b/udiskie/.config/udiskie/config.yml
@@ -1,0 +1,5 @@
+program_options:
+  automount: true
+  notify: true
+  tray: false
+

--- a/waybar/.config/waybar/config.jsonc
+++ b/waybar/.config/waybar/config.jsonc
@@ -21,7 +21,7 @@
         // "mpd",
         // "idle_inhibitor",
         // "custom/weather",
-        "tray",
+        "custom/udiskie",
         "custom/swaync",
         "pulseaudio",
         // "power-profiles-daemon",
@@ -109,13 +109,14 @@
         "on-click": "swaync-client -t -sw",
         "on-click-right": "swaync-client -d -sw"
     },
-    "tray": {
-        // "icon-size": 21,
-        "spacing": 10,
-        // "icons": {
-        //   "blueman": "bluetooth",
-        //   "TelegramDesktop": "$HOME/.local/share/icons/hicolor/16x16/apps/telegram.png"
-        // }
+    "custom/udiskie": {
+        "tooltip": true,
+        "format": "<span size='13000'>󰋊</span>{}",
+        "return-type": "json",
+        "exec": "~/.config/waybar/scripts/udiskie-status.sh",
+        "interval": 3,
+        "on-click": "~/.config/waybar/scripts/udiskie-eject.sh",
+        "on-click-right": "nautilus /run/media/anotherjson 2>/dev/null"
     },
     "clock": {
         // "timezone": "America/New_York",

--- a/waybar/.config/waybar/config.jsonc
+++ b/waybar/.config/waybar/config.jsonc
@@ -116,7 +116,7 @@
         "exec": "~/.config/waybar/scripts/udiskie-status.sh",
         "interval": 3,
         "on-click": "~/.config/waybar/scripts/udiskie-eject.sh",
-        "on-click-right": "nautilus /run/media/anotherjson 2>/dev/null"
+        "on-click-right": "nautilus \"/run/media/$USER\" 2>/dev/null"
     },
     "clock": {
         // "timezone": "America/New_York",

--- a/waybar/.config/waybar/scripts/cycle_audio_sink.sh
+++ b/waybar/.config/waybar/scripts/cycle_audio_sink.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+#
+# cycle_audio_sink.sh — Cycle the default audio output sink,
+# skipping HDMI sinks. Moves all active streams to the new sink
+# and sends a desktop notification.
+
+set -euo pipefail
+
+get_eligible_sinks() {
+    pactl list sinks short \
+        | awk '{print $2}' \
+        | grep -v 'HDMI'
+}
+
+get_default_sink() {
+    pactl get-default-sink
+}
+
+get_sink_description() {
+    local sink_name="$1"
+    pactl list sinks \
+        | grep -A1 "Name: ${sink_name}$" \
+        | grep 'Description:' \
+        | sed 's/.*Description: //'
+}
+
+move_all_streams() {
+    local target_sink="$1"
+    pactl list sink-inputs short \
+        | awk '{print $1}' \
+        | while read -r input_id; do
+            pactl move-sink-input "$input_id" "$target_sink" 2>/dev/null || true
+        done
+}
+
+notify() {
+    local description="$1"
+    notify-send \
+        --app-name="Audio" \
+        --urgency=low \
+        --expire-time=2000 \
+        --hint=string:x-canonical-private-synchronous:audio-sink \
+        "Audio Output" \
+        "Switched to: ${description}"
+}
+
+main() {
+    local current_sink
+    current_sink="$(get_default_sink)"
+
+    local -a sinks
+    mapfile -t sinks < <(get_eligible_sinks)
+
+    local count="${#sinks[@]}"
+
+    if (( count == 0 )); then
+        notify-send --urgency=critical "Audio" "No eligible audio sinks found"
+        exit 1
+    fi
+
+    if (( count == 1 )); then
+        notify "$(get_sink_description "${sinks[0]}") (only device)"
+        exit 0
+    fi
+
+    local current_index=-1
+    for i in "${!sinks[@]}"; do
+        if [[ "${sinks[$i]}" == "$current_sink" ]]; then
+            current_index="$i"
+            break
+        fi
+    done
+
+    local next_index=$(( (current_index + 1) % count ))
+    local next_sink="${sinks[$next_index]}"
+
+    pactl set-default-sink "$next_sink"
+    move_all_streams "$next_sink"
+
+    local description
+    description="$(get_sink_description "$next_sink")"
+    notify "$description"
+}
+
+main "$@"

--- a/waybar/.config/waybar/scripts/get_weather.sh
+++ b/waybar/.config/waybar/scripts/get_weather.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+for i in {1..5}
+do
+    text=$(curl -s "https://wttr.in/$1?format=2")
+    if [[ $? == 0 ]]
+    then
+        text=$(echo "$text" | sed -E "s/\s+/ /g")
+        tooltip=$(curl -s "https://wttr.in/$1?format=2")
+        if [[ $? == 0 ]]
+        then
+            tooltip=$(echo "$tooltip" | sed -E "s/\s+/ /g")
+            echo "{\"text\":\"$text\", \"tooltip\":\"$tooltip\"}"
+            exit
+        fi
+    fi
+    sleep 2
+done
+echo "{\"text\":\"error\", \"tooltip\":\"error\"}"

--- a/waybar/.config/waybar/scripts/udiskie-eject.sh
+++ b/waybar/.config/waybar/scripts/udiskie-eject.sh
@@ -1,15 +1,16 @@
 #!/usr/bin/env bash
 # Wofi picker for per-device eject of udiskie-mounted removable media.
+set -euo pipefail
 shopt -s nullglob
 mounts=(/run/media/"$USER"/*/)
-[ ${#mounts[@]} -eq 0 ] && exit 0
+[ ${#mounts[@]} -ne 0 ] || exit 0
 
 items=()
 for m in "${mounts[@]}"; do items+=("$(basename "$m")"); done
 items+=("(eject all)")
 
-choice=$(printf '%s\n' "${items[@]}" | wofi --dmenu --prompt "Eject:" --width 280 --height 240)
-[ -z "$choice" ] && exit 0
+choice=$(printf '%s\n' "${items[@]}" | wofi --dmenu --prompt "Eject:" --width 280 --height 240) || exit 0
+[ -n "$choice" ] || exit 0
 
 if [ "$choice" = "(eject all)" ]; then
     udiskie-umount --all

--- a/waybar/.config/waybar/scripts/udiskie-eject.sh
+++ b/waybar/.config/waybar/scripts/udiskie-eject.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Wofi picker for per-device eject of udiskie-mounted removable media.
+shopt -s nullglob
+mounts=(/run/media/"$USER"/*/)
+[ ${#mounts[@]} -eq 0 ] && exit 0
+
+items=()
+for m in "${mounts[@]}"; do items+=("$(basename "$m")"); done
+items+=("(eject all)")
+
+choice=$(printf '%s\n' "${items[@]}" | wofi --dmenu --prompt "Eject:" --width 280 --height 240)
+[ -z "$choice" ] && exit 0
+
+if [ "$choice" = "(eject all)" ]; then
+    udiskie-umount --all
+else
+    udiskie-umount "/run/media/$USER/$choice"
+fi

--- a/waybar/.config/waybar/scripts/udiskie-status.sh
+++ b/waybar/.config/waybar/scripts/udiskie-status.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Emit waybar JSON describing currently-mounted removable media under /run/media/$USER.
 # Uses jq to encode newlines safely so multi-label tooltips don't break JSON parsing.
+set -euo pipefail
 shopt -s nullglob
 mounts=(/run/media/"$USER"/*/)
 count=${#mounts[@]}

--- a/waybar/.config/waybar/scripts/udiskie-status.sh
+++ b/waybar/.config/waybar/scripts/udiskie-status.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Emit waybar JSON describing currently-mounted removable media under /run/media/$USER.
+# Uses jq to encode newlines safely so multi-label tooltips don't break JSON parsing.
+shopt -s nullglob
+mounts=(/run/media/"$USER"/*/)
+count=${#mounts[@]}
+
+if [ "$count" -eq 0 ]; then
+    jq -nc \
+        --arg text "" \
+        --arg tooltip "No removable media mounted" \
+        --arg class "empty" \
+        '{text: $text, tooltip: $tooltip, class: $class}'
+else
+    labels=()
+    for m in "${mounts[@]}"; do labels+=("$(basename "$m")"); done
+    tooltip=$(printf '%s\n' "${labels[@]}")
+    tooltip=${tooltip%$'\n'}
+    jq -nc \
+        --arg text " $count" \
+        --arg tooltip "$tooltip" \
+        --arg class "mounted" \
+        '{text: $text, tooltip: $tooltip, class: $class}'
+fi

--- a/waybar/.config/waybar/style.css
+++ b/waybar/.config/waybar/style.css
@@ -152,13 +152,13 @@ button {
 }
 
 #custom-udiskie {
-    color: #2AA198;                       /* Solarized cyan500 — idle */
-    border-bottom: 2px solid #2AA198;
+    color: @teal;
+    border-bottom: 2px solid @teal;
 }
 
 #custom-udiskie.mounted {
-    color: #859900;                       /* Solarized green500 — mounted */
-    border-bottom: 2px solid #859900;
+    color: @green;
+    border-bottom: 2px solid @green;
 }
 
 #custom-vpn {

--- a/waybar/.config/waybar/style.css
+++ b/waybar/.config/waybar/style.css
@@ -60,6 +60,7 @@ button {
 }
 
 #custom-swaync,
+#custom-udiskie,
 #pulseaudio,
 #clock,
 #battery,
@@ -148,6 +149,16 @@ button {
 #custom-swaync {
     color: @violet;
     border-bottom: 2px solid @violet;
+}
+
+#custom-udiskie {
+    color: #2AA198;                       /* Solarized cyan500 — idle */
+    border-bottom: 2px solid #2AA198;
+}
+
+#custom-udiskie.mounted {
+    color: #859900;                       /* Solarized green500 — mounted */
+    border-bottom: 2px solid #859900;
 }
 
 #custom-vpn {


### PR DESCRIPTION
## Summary

- Install darktable, udiskie, and exfatprogs; enable udisks2 systemd service for automatic SD card mounting
- Replace deprecated udiskie tray with custom waybar module for per-device eject via wofi picker
- Fix Hyprland 0.55 API breaks (pseudotile removal, togglesplit dispatcher change)
- Add global Claude convention: use yay for all package operations (install/query/search/file-owns)

## Changes

**Justfile**
- Extended `_pkgs` with `udiskie exfatprogs darktable` (lensfun is a transitive dep of darktable, not explicit)
- Swapped `wezterm` → `wezterm-git` to match user's AUR pin and avoid pacman conflicts
- Updated bootstrap epilog to document `sudo systemctl enable --now udisks2` as a manual step

**Hyprland config**
- Added `$diskmanager = udiskie` variable (line ~47)
- Updated `exec-once` to append `$diskmanager` (line ~60)
- Removed `dwindle:pseudotile = true` (0.55 API change; per-window via layoutmsg dispatcher)
- Fixed `bind = $mainMod, s, togglesplit,` → `bind = $mainMod, s, layoutmsg, togglesplit` (0.54+ API)

**Udiskie stow package** (new)
- Created `udiskie/.config/udiskie/config.yml` with minimal V1 config: automount+notify enabled, tray disabled (uses custom waybar module instead)

**Waybar config & scripts**
- Replaced `tray` module with `custom/udiskie` in `modules-right` array
- Added `custom/udiskie` module definition: JSON status script + wofi on-click, nautilus on-click-right
- Added two new executable scripts:
  - `udiskie-status.sh`: emits JSON with mount count, device labels in tooltip, CSS class for state
  - `udiskie-eject.sh`: wofi picker for per-device eject (allows unmounting one card while keeping others mounted)
- Added `#custom-udiskie` CSS rules: Solarized cyan500 (idle) / green500 (mounted state)

**Claude global convention**
- Updated `claude/CLAUDE.md` to mandate `yay` for all package operations (never bare `pacman`)

**.gitignore**
- Added `!waybar/.config/waybar/scripts/` negation to track waybar scripts (matches hypr's pattern)

## Test plan

- [ ] Package install: `yay -Q udiskie darktable exfatprogs` confirms all installed
- [ ] Service active: `systemctl is-active udisks2` → active and enabled
- [ ] Udiskie config: `grep tray ~/.config/udiskie/config.yml` → `tray: false`
- [ ] Waybar chip visible after reload: cyan disk icon in waybar's right side
- [ ] Mount a camera SD card: notify popup appears, chip turns green, tooltip shows label
- [ ] Waybar chip click: wofi shows mounted labels + "(eject all)", eject selection unmounts only that device
- [ ] Darktable launch + import: `wofi → dark → File → Import → /run/media/$USER/<LABEL>/DCIM/` → RAW thumbnails render
- [ ] Eject via chip: waybar chip count decrements, remaining mounts stay mounted
- [ ] Hyprland config valid: `hyprctl reload` → no errors

🤖 Generated via `/pr` skill