### PR TITLE
Add typed bootstrap and per-host autodetect for multi-machine setup

### DIFF
--- a/.github/workflows/assert-bootstrap.sh
+++ b/.github/workflows/assert-bootstrap.sh
@@ -36,6 +36,12 @@ assert_resolves_to "$HOME/.config/kitty/kitty.conf" \
 assert_resolves_to "$HOME/.config/waybar/config.jsonc" \
     "$dotfiles/waybar/.config/waybar/config.jsonc"
 
+# host-init linked the desktop variants (no BAT* in CI container)
+assert_resolves_to "$HOME/.config/hypr/host.conf" \
+    "$dotfiles/hosts/hypr/host.conf.desktop"
+assert_resolves_to "$HOME/.config/waybar/host.jsonc" \
+    "$dotfiles/hosts/waybar/host.jsonc.desktop"
+
 # wofi package
 assert_resolves_to "$HOME/.config/wofi/style.css" \
     "$dotfiles/wofi/.config/wofi/style.css"

--- a/.github/workflows/assert-bootstrap.sh
+++ b/.github/workflows/assert-bootstrap.sh
@@ -20,7 +20,7 @@ assert_resolves_to() {
     }
 }
 
-# stow-all linked the hypr package
+# stow-bundle linked the hypr package
 assert_resolves_to "$HOME/.config/hypr/hyprland.conf" \
     "$dotfiles/hypr/.config/hypr/hyprland.conf"
 
@@ -59,32 +59,25 @@ assert_resolves_to "$HOME/.config/starship.toml" \
 # zsh package (top-level dotfile)
 assert_resolves_to "$HOME/.zshrc" "$dotfiles/zsh/.zshrc"
 
-# claude-deploy is copy-based — files must exist and NOT be symlinks
-[ -f "$HOME/.claude/settings.json" ] \
-    || { echo "FAIL: ~/.claude/settings.json missing"; exit 1; }
-[ ! -L "$HOME/.claude/settings.json" ] \
-    || { echo "FAIL: ~/.claude/settings.json is a symlink (should be a copy)"; exit 1; }
-cmp -s "$HOME/.claude/settings.json" "$dotfiles/claude/settings.json" \
-    || { echo "FAIL: ~/.claude/settings.json content differs from repo"; exit 1; }
-[ -f "$HOME/.claude/CLAUDE.md" ] \
-    || { echo "FAIL: ~/.claude/CLAUDE.md missing"; exit 1; }
-
-# claude/ and guides/ must be excluded from stow-all
+# claude/ and guides/ must be excluded from stow-bundle
 [ ! -L "$HOME/.config/claude" ] \
     || { echo "FAIL: claude/ got stowed"; exit 1; }
 [ ! -e "$HOME/guides" ] \
     || { echo "FAIL: guides/ got stowed"; exit 1; }
 
-# firefox-deploy linked chrome/ into the fake profile
-profile="$HOME/.mozilla/firefox/test.default-release"
-[ -L "$profile/chrome" ] \
-    || { echo "FAIL: $profile/chrome is not a symlink"; exit 1; }
-target="$(readlink "$profile/chrome")"
-[ "$target" = "$dotfiles/firefox/chrome" ] || {
-    echo "FAIL: firefox chrome/ symlink"
-    echo "  expected: $dotfiles/firefox/chrome"
-    echo "  actual:   $target"
-    exit 1
-}
+# Production-only stow packages must NOT land for base
+[ ! -e "$HOME/.config/opencode" ] \
+    || { echo "FAIL: opencode/ stowed for base (should be production-only)"; exit 1; }
+[ ! -e "$HOME/.config/gemini" ] \
+    || { echo "FAIL: gemini/ stowed for base (should be production-only)"; exit 1; }
+
+# install-claude must not have run for base (the $CI guard is verified in a
+# dedicated workflow step; assert defensively here too)
+[ ! -x "$HOME/.local/bin/claude" ] \
+    || { echo "FAIL: claude binary present after base deploy"; exit 1; }
+
+# claude-deploy must not have run for base
+[ ! -e "$HOME/.claude/settings.json" ] \
+    || { echo "FAIL: ~/.claude/settings.json present after base deploy"; exit 1; }
 
 echo "all assertions passed"

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -31,6 +31,9 @@ jobs:
           mv "$GITHUB_WORKSPACE/dotfiles" "$AB_HOME/.dotfiles"
           chown -R ab:ab "$AB_HOME"
 
+      # Mirrors the multilib check in justfile's _preflight; both must stay in
+      # sync. CI is the only place we *enable* multilib non-interactively; users
+      # get a clear error message from _preflight on real machines.
       - name: Enable multilib (needed to resolve `steam` from the gaming bundle)
         run: |
           if ! grep -qE '^\[multilib\]' /etc/pacman.conf; then
@@ -58,17 +61,27 @@ jobs:
             exit $failed
           '
 
-      - name: Fake firefox profile
-        run: runuser -u ab -- mkdir -p "$AB_HOME/.mozilla/firefox/test.default-release"
+      - name: Verify install-claude CI guard
+        run: |
+          runuser -u ab -- bash -lc '
+            set -euo pipefail
+            cd "$HOME/.dotfiles"
+            output=$(just install-claude)
+            echo "$output"
+            echo "$output" | grep -q "CI detected" \
+                || { echo "FAIL: install-claude did not detect CI"; exit 1; }
+            [ ! -x "$HOME/.local/bin/claude" ] \
+                || { echo "FAIL: claude binary appeared despite CI guard"; exit 1; }
+          '
 
-      - name: First deploy-all
-        run: runuser -u ab -- bash -lc 'cd "$HOME/.dotfiles" && just deploy-all production'
+      - name: First deploy
+        run: runuser -u ab -- bash -lc 'cd "$HOME/.dotfiles" && just deploy base'
 
       - name: Assert deploy outcomes
         run: runuser -u ab -- bash "$AB_HOME/.dotfiles/.github/workflows/assert-bootstrap.sh"
 
-      - name: Second deploy-all (idempotency)
-        run: runuser -u ab -- bash -lc 'cd "$HOME/.dotfiles" && just deploy-all production'
+      - name: Second deploy (idempotency)
+        run: runuser -u ab -- bash -lc 'cd "$HOME/.dotfiles" && just deploy base'
 
       - name: Re-assert after second run
         run: runuser -u ab -- bash "$AB_HOME/.dotfiles/.github/workflows/assert-bootstrap.sh"

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -47,7 +47,7 @@ jobs:
                 echo "FAIL: $p not found in any repo or AUR"
                 failed=1
               fi
-            done < <(just install-deps-list)
+            done < <(just install-deps-list all)
             exit $failed
           '
 
@@ -55,13 +55,13 @@ jobs:
         run: runuser -u ab -- mkdir -p "$AB_HOME/.mozilla/firefox/test.default-release"
 
       - name: First deploy-all
-        run: runuser -u ab -- bash -lc 'cd "$HOME/.dotfiles" && just deploy-all'
+        run: runuser -u ab -- bash -lc 'cd "$HOME/.dotfiles" && just deploy-all production'
 
       - name: Assert deploy outcomes
         run: runuser -u ab -- bash "$AB_HOME/.dotfiles/.github/workflows/assert-bootstrap.sh"
 
       - name: Second deploy-all (idempotency)
-        run: runuser -u ab -- bash -lc 'cd "$HOME/.dotfiles" && just deploy-all'
+        run: runuser -u ab -- bash -lc 'cd "$HOME/.dotfiles" && just deploy-all production'
 
       - name: Re-assert after second run
         run: runuser -u ab -- bash "$AB_HOME/.dotfiles/.github/workflows/assert-bootstrap.sh"

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -31,6 +31,13 @@ jobs:
           mv "$GITHUB_WORKSPACE/dotfiles" "$AB_HOME/.dotfiles"
           chown -R ab:ab "$AB_HOME"
 
+      - name: Enable multilib (needed to resolve `steam` from the gaming bundle)
+        run: |
+          if ! grep -qE '^\[multilib\]' /etc/pacman.conf; then
+            printf '\n[multilib]\nInclude = /etc/pacman.d/mirrorlist\n' >> /etc/pacman.conf
+          fi
+          pacman -Sy --noconfirm
+
       - name: Install non-GUI subset
         run: |
           pacman -Syu --noconfirm --needed \

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Each top-level directory is a stow package mirroring its target path inside
 | `backgrounds` | Wallpapers |
 
 Platform-specific setup quicknotes live in [`guides/`](guides/):
+- [`guides/host-config.md`](guides/host-config.md) — typed bootstrap +
+  per-host autodetect
 - [`guides/arch.md`](guides/arch.md) — Arch nvim/pyenv quicknotes
 - [`guides/macbook-air-ubuntu.md`](guides/macbook-air-ubuntu.md) — legacy
   MacBook Air on Ubuntu
@@ -52,27 +54,47 @@ repo, then bootstrap from inside it:
 ```zsh
 git clone https://github.com/anotherjson/anotherdot.git ~/.dotfiles
 cd ~/.dotfiles
-just bootstrap
+just bootstrap                  # defaults to type=base
+just bootstrap type=production  # base + firefox/nautilus/darktable + claude/gemini/opencode
+just bootstrap type=gaming      # base + steam (strict — no firefox/claude/gemini)
+just bootstrap type=all         # everything
 ```
 
-`just bootstrap` runs two recipes: `install-deps` (`yay -S --needed` for the
-full system-package list — Hyprland stack, audio, terminals, editor, theme,
-fonts, scripted CLI tools) and `deploy-all` (stows every package, then runs
-the Claude copy-deploy and Firefox symlink-deploy). At the end it prints any
-manual steps remaining — notably setting zsh as the default shell and
-reloading Hyprland.
+| Type         | What's installed                                                                                                                  |
+|--------------|-----------------------------------------------------------------------------------------------------------------------------------|
+| `base`       | Hyprland WM stack, terminals, editor, shell, audio, theme/font, dotfile tooling. Minimal usable Hyprland desktop.                 |
+| `production` | `base` + firefox, nautilus, darktable, opencode. Stows gemini + opencode configs. Runs claude/firefox deploys.                    |
+| `gaming`     | `base` + steam. Requires `[multilib]` enabled in `/etc/pacman.conf`. Intentionally strict — no AI/browser tooling.                |
+| `all`        | Union of `production` + `gaming`. Multilib required.                                                                              |
 
-The package list is the source of truth; see the `install-deps` recipe in
-[`justfile`](justfile) to inspect or add packages.
+`just bootstrap` runs three recipes: `_preflight` (validates required
+commands and, for gaming/all, multilib), `install-deps` (`yay -S --needed`
+for the bundle), and `deploy-all` (stows the relevant packages, runs
+`host-init` to symlink laptop-vs-desktop config variants, and for
+production/all runs the Claude and Firefox special-case deploys). At the
+end it prints any manual steps remaining — notably setting zsh as the
+default shell and reloading Hyprland.
+
+`host-init` autodetects laptop vs. desktop via `/sys/class/power_supply/BAT*`
+and links the right variant from `hosts/`. See
+[`guides/host-config.md`](guides/host-config.md) for details and how to
+force-override.
+
+To inspect what `install-deps` will install for a given type:
+
+```zsh
+just install-deps-list <type>
+```
 
 ## Day-to-day commands
 
 ```zsh
-dots stow <pkg>      # stow a single package
-dots restow <pkg>    # unstow + stow (after package changes)
-dots unstow <pkg>    # remove the symlinks
-dots stow-all        # stow every package (skips claude/, guides/)
-dots deploy-all      # stow-all + claude-deploy + firefox-deploy
+dots stow <pkg>            # stow a single package
+dots restow <pkg>          # unstow + stow (after package changes)
+dots unstow <pkg>          # remove the symlinks
+dots stow-all [type]       # stow the packages for the given type (default: base)
+dots deploy-all [type]     # host-init + stow-all + (production: claude + firefox)
+dots host-init             # re-detect laptop/desktop and refresh host.{conf,jsonc}
 ```
 
 ## Firefox config

--- a/README.md
+++ b/README.md
@@ -54,47 +54,26 @@ repo, then bootstrap from inside it:
 ```zsh
 git clone https://github.com/anotherjson/anotherdot.git ~/.dotfiles
 cd ~/.dotfiles
-just bootstrap                  # defaults to type=base
-just bootstrap type=production  # base + firefox/nautilus/darktable + claude/gemini/opencode
-just bootstrap type=gaming      # base + steam (strict — no firefox/claude/gemini)
-just bootstrap type=all         # everything
+just bootstrap
 ```
 
-| Type         | What's installed                                                                                                                  |
-|--------------|-----------------------------------------------------------------------------------------------------------------------------------|
-| `base`       | Hyprland WM stack, terminals, editor, shell, audio, theme/font, dotfile tooling. Minimal usable Hyprland desktop.                 |
-| `production` | `base` + firefox, nautilus, darktable, opencode. Stows gemini + opencode configs. Runs claude/firefox deploys.                    |
-| `gaming`     | `base` + steam. Requires `[multilib]` enabled in `/etc/pacman.conf`. Intentionally strict — no AI/browser tooling.                |
-| `all`        | Union of `production` + `gaming`. Multilib required.                                                                              |
+`just bootstrap` runs `_preflight`, `install-deps` (`yay -S --needed` for
+the system-package list), and `deploy` (stows packages, runs host-init for
+laptop-vs-desktop config variants, and for production/all runs the Claude
+and Firefox special-case deploys). At the end it prints any manual steps
+remaining — notably setting zsh as the default shell and reloading Hyprland.
 
-`just bootstrap` runs three recipes: `_preflight` (validates required
-commands and, for gaming/all, multilib), `install-deps` (`yay -S --needed`
-for the bundle), and `deploy-all` (stows the relevant packages, runs
-`host-init` to symlink laptop-vs-desktop config variants, and for
-production/all runs the Claude and Firefox special-case deploys). At the
-end it prints any manual steps remaining — notably setting zsh as the
-default shell and reloading Hyprland.
-
-`host-init` autodetects laptop vs. desktop via `/sys/class/power_supply/BAT*`
-and links the right variant from `hosts/`. See
-[`guides/host-config.md`](guides/host-config.md) for details and how to
-force-override.
-
-To inspect what `install-deps` will install for a given type:
-
-```zsh
-just install-deps-list <type>
-```
+Pass `type=...` to select a bundle — see
+[`guides/host-config.md`](guides/host-config.md).
 
 ## Day-to-day commands
 
 ```zsh
-dots stow <pkg>            # stow a single package
-dots restow <pkg>          # unstow + stow (after package changes)
-dots unstow <pkg>          # remove the symlinks
-dots stow-all [type]       # stow the packages for the given type (default: base)
-dots deploy-all [type]     # host-init + stow-all + (production: claude + firefox)
-dots host-init             # re-detect laptop/desktop and refresh host.{conf,jsonc}
+dots stow <pkg>      # stow a single package
+dots restow <pkg>    # unstow + stow (after package changes)
+dots unstow <pkg>    # remove the symlinks
+dots stow-bundle     # stow every package for the given type
+dots deploy          # stow-bundle + host-init + (production: claude + firefox)
 ```
 
 ## Firefox config

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Each top-level directory is a stow package mirroring its target path inside
 | [`claude`](claude/README.md) | Claude Code config (copy-based) |
 | `gemini` | Gemini CLI config |
 | [`opencode`](opencode/README.md) | opencode TUI agent (bundled free model, no account) |
+| `udiskie` | Removable-media automount tray |
 | `backgrounds` | Wallpapers |
 
 Platform-specific setup quicknotes live in [`guides/`](guides/):
@@ -57,14 +58,9 @@ cd ~/.dotfiles
 just bootstrap
 ```
 
-`just bootstrap` runs `_preflight`, `install-deps` (`yay -S --needed` for
-the system-package list), and `deploy` (stows packages, runs host-init for
-laptop-vs-desktop config variants, and for production/all runs the Claude
-and Firefox special-case deploys). At the end it prints any manual steps
-remaining — notably setting zsh as the default shell and reloading Hyprland.
-
-Pass `type=...` to select a bundle — see
-[`guides/host-config.md`](guides/host-config.md).
+Defaults to the `base` bundle. Pass `type=production|gaming|all` to install
+more — see [`guides/host-config.md`](guides/host-config.md) for what each
+bundle includes and how the laptop/desktop autodetect works.
 
 ## Day-to-day commands
 

--- a/guides/host-config.md
+++ b/guides/host-config.md
@@ -48,6 +48,10 @@ Output goes to `~/.config/hypr/host.conf` and `~/.config/waybar/host.jsonc`.
 The main Hyprland config sources the first; the main waybar config
 includes the second.
 
+`just stow hypr`, `just stow waybar` (and their `restow` counterparts)
+also chain `host-init` automatically, so single-package stows don't leave
+the include target dangling. Other packages aren't affected.
+
 The laptop branch is exercised only by manual runs on a laptop; CI covers
 the desktop branch and the symlink mechanics.
 

--- a/guides/host-config.md
+++ b/guides/host-config.md
@@ -30,7 +30,7 @@ this before any install.
 
 ## Per-host autodetect
 
-`just host-init` (also run automatically as part of `deploy-all`) detects
+`just host-init` (also run automatically as part of `deploy`) detects
 whether the machine is a laptop by checking for `/sys/class/power_supply/BAT*`
 and symlinks the matching variant from `hosts/`:
 
@@ -47,6 +47,14 @@ hosts/
 Output goes to `~/.config/hypr/host.conf` and `~/.config/waybar/host.jsonc`.
 The main Hyprland config sources the first; the main waybar config
 includes the second.
+
+The laptop branch is exercised only by manual runs on a laptop; CI covers
+the desktop branch and the symlink mechanics.
+
+CI tests the `base` type only. Production-specific recipes (`claude-deploy`,
+`firefox-deploy`, `install-claude`, `firefox-profile-init`) are exercised
+manually via `just bootstrap type=production` on real hardware — see the
+verification section of any change that touches them.
 
 ## Force-overriding the autodetect
 

--- a/guides/host-config.md
+++ b/guides/host-config.md
@@ -1,0 +1,70 @@
+# Host config
+
+Two orthogonal mechanisms keep one repo working across multiple machines:
+typed bootstrap (chooses *what* to install) and host autodetect (chooses
+*which laptop-vs-desktop bits* to wire up).
+
+## Typed bootstrap
+
+```zsh
+just bootstrap type=<base|production|gaming|all>
+```
+
+| Type         | System packages                                                | Stow packages                          |
+|--------------|----------------------------------------------------------------|----------------------------------------|
+| `base`       | Hyprland WM stack, terminals, editor, shell, audio, theme/font | hypr, waybar, wofi, kitty, wezterm, nvim, zsh, starship, gtk, udiskie, backgrounds |
+| `production` | `base` + firefox, nautilus, darktable, opencode                | base + gemini, opencode                |
+| `gaming`     | `base` + steam (strict — no firefox/claude/gemini/opencode)    | base                                   |
+| `all`        | union of production + gaming                                   | base + gemini, opencode                |
+
+`just bootstrap` with no argument defaults to `base`.
+
+`production` and `all` additionally run `install-claude` (curl installer),
+`claude-deploy` (copy claude/ config), `firefox-profile-init` (launch
+firefox headless once to seed a default profile), and `firefox-deploy`
+(symlink chrome/ into the profile).
+
+`gaming` and `all` require the `[multilib]` repo enabled in
+`/etc/pacman.conf` (steam pulls lib32-* dependencies). `_preflight` checks
+this before any install.
+
+## Per-host autodetect
+
+`just host-init` (also run automatically as part of `deploy-all`) detects
+whether the machine is a laptop by checking for `/sys/class/power_supply/BAT*`
+and symlinks the matching variant from `hosts/`:
+
+```
+hosts/
+├── hypr/
+│   ├── host.conf.laptop     # eDP-1 monitor, brightness keybinds
+│   └── host.conf.desktop    # empty (catch-all monitor= already covers it)
+└── waybar/
+    ├── host.jsonc.laptop    # modules-right with battery + backlight
+    └── host.jsonc.desktop   # modules-right without battery/backlight
+```
+
+Output goes to `~/.config/hypr/host.conf` and `~/.config/waybar/host.jsonc`.
+The main Hyprland config sources the first; the main waybar config
+includes the second.
+
+## Force-overriding the autodetect
+
+If you want to e.g. run laptop config on a desktop, re-link by hand after
+`host-init` (or in place of it):
+
+```zsh
+ln -sfn "$HOME/.dotfiles/hosts/hypr/host.conf.laptop"    ~/.config/hypr/host.conf
+ln -sfn "$HOME/.dotfiles/hosts/waybar/host.jsonc.laptop" ~/.config/waybar/host.jsonc
+```
+
+Then reload: `hyprctl reload` and `killall waybar && waybar &`.
+
+## Adding a new host bit
+
+1. Add the snippet to both `hosts/hypr/host.conf.{laptop,desktop}` and/or
+   `hosts/waybar/host.jsonc.{laptop,desktop}` — keep the file structure
+   parallel so the autodetect just works.
+2. Commit.
+3. On each machine: `just host-init` to refresh the symlink, then
+   `hyprctl reload` / restart waybar.

--- a/hosts/hypr/host.conf.desktop
+++ b/hosts/hypr/host.conf.desktop
@@ -1,0 +1,3 @@
+# Desktop Hyprland overrides. Symlinked into place by `just host-init`
+# when no battery is detected. Intentionally empty — the catch-all
+# `monitor=,preferred,auto,auto` in hyprland.conf covers desktop monitors.

--- a/hosts/hypr/host.conf.laptop
+++ b/hosts/hypr/host.conf.laptop
@@ -1,0 +1,7 @@
+# Laptop Hyprland overrides. Symlinked into place by `just host-init`
+# when /sys/class/power_supply/BAT* exists.
+
+monitor = eDP-1, preferred, auto, 2
+
+bindel = , XF86MonBrightnessUp,   exec, brightnessctl -e4 -n2 set 5%+
+bindel = , XF86MonBrightnessDown, exec, brightnessctl -e4 -n2 set 5%-

--- a/hosts/waybar/host.jsonc.desktop
+++ b/hosts/waybar/host.jsonc.desktop
@@ -1,0 +1,14 @@
+// Desktop waybar overrides. Symlinked into place by `just host-init` when
+// no battery is detected. Merged into the main config via the `"include"`
+// directive in waybar/.config/waybar/config.jsonc.
+{
+    "modules-right": [
+        "custom/udiskie",
+        "custom/swaync",
+        "pulseaudio",
+        "cpu",
+        "memory",
+        "temperature",
+        "network"
+    ]
+}

--- a/hosts/waybar/host.jsonc.laptop
+++ b/hosts/waybar/host.jsonc.laptop
@@ -1,0 +1,36 @@
+// Laptop waybar overrides. Symlinked into place by `just host-init`
+// when /sys/class/power_supply/BAT* exists. Merged into the main config via
+// the `"include"` directive in waybar/.config/waybar/config.jsonc.
+{
+    "modules-right": [
+        "custom/udiskie",
+        "custom/swaync",
+        "pulseaudio",
+        "cpu",
+        "memory",
+        "temperature",
+        "backlight",
+        "network",
+        "battery"
+    ],
+    "backlight": {
+        "format": "<span size='13000'>{icon} </span> {percent}% ",
+        "tooltip-format": "{percent}%",
+        "format-icons": ["", "", "", "", "", "", "", "", ""]
+    },
+    "battery": {
+        "states": {
+            "warning": 30,
+            "critical": 15
+        },
+        "format": "<span size='13000'>{icon} </span> {capacity}%",
+        "format-alt": "<span size='13000'>{icon} </span> {time}",
+        "format-full": "<span size='13000'> </span>{capacity}%",
+        "format-warning": "<span size='13000'>{icon} </span> {capacity}%",
+        "format-critical": "<span size='13000'>{icon} </span> {capacity}%",
+        "format-charging": "<span size='13000'> </span>{capacity}%",
+        "format-plugged": "<span size='13000'> </span>{capacity}%",
+        "format-icons": ["", "", "", "", ""],
+        "tooltip-format": "{time}"
+    }
+}

--- a/hosts/waybar/host.jsonc.laptop
+++ b/hosts/waybar/host.jsonc.laptop
@@ -25,11 +25,11 @@
         },
         "format": "<span size='13000'>{icon} </span> {capacity}%",
         "format-alt": "<span size='13000'>{icon} </span> {time}",
-        "format-full": "<span size='13000'> </span>{capacity}%",
+        "format-full": "<span size='13000'> </span>{capacity}%",
         "format-warning": "<span size='13000'>{icon} </span> {capacity}%",
         "format-critical": "<span size='13000'>{icon} </span> {capacity}%",
-        "format-charging": "<span size='13000'> </span>{capacity}%",
-        "format-plugged": "<span size='13000'> </span>{capacity}%",
+        "format-charging": "<span size='13000'> </span>{capacity}%",
+        "format-plugged": "<span size='13000'> </span>{capacity}%",
         "format-icons": ["", "", "", "", ""],
         "tooltip-format": "{time}"
     }

--- a/hypr/.config/hypr/hyprland.conf
+++ b/hypr/.config/hypr/hyprland.conf
@@ -24,8 +24,8 @@ source=~/.config/hypr/solarized_osaka.conf
 ################
 
 # See https://wiki.hyprland.org/Configuring/Monitors/
+# Per-host monitor declarations live in ~/.config/hypr/host.conf (sourced at end of file).
 monitor=,preferred,auto,auto
-monitor=eDP-1,preferred,auto,2
 
 
 ###################
@@ -311,8 +311,7 @@ bindel = ,XF86AudioRaiseVolume, exec, wpctl set-volume -l 1 @DEFAULT_AUDIO_SINK@
 bindel = ,XF86AudioLowerVolume, exec, wpctl set-volume @DEFAULT_AUDIO_SINK@ 5%-
 bindel = ,XF86AudioMute, exec, wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle
 bindel = ,XF86AudioMicMute, exec, wpctl set-mute @DEFAULT_AUDIO_SOURCE@ toggle
-bindel = ,XF86MonBrightnessUp, exec, brightnessctl -e4 -n2 set 5%+
-bindel = ,XF86MonBrightnessDown, exec, brightnessctl -e4 -n2 set 5%-
+# Brightness binds (laptop-only) live in ~/.config/hypr/host.conf.
 
 # Requires playerctl
 bindl = , XF86AudioNext, exec, playerctl next
@@ -338,3 +337,6 @@ windowrule = suppress_event maximize, match:class .*
 
 # Fix some dragging issues with XWayland
 windowrule = no_focus on, match:class ^$, match:title ^$, match:xwayland 1, match:float 1, match:fullscreen 0, match:pin 0
+
+# Per-host overrides (monitor decl, laptop binds, etc.). See guides/host-config.md.
+source = ~/.config/hypr/host.conf

--- a/hypr/.config/hypr/hyprland.conf
+++ b/hypr/.config/hypr/hyprland.conf
@@ -24,7 +24,6 @@ source=~/.config/hypr/solarized_osaka.conf
 ################
 
 # See https://wiki.hyprland.org/Configuring/Monitors/
-# Per-host monitor declarations live in ~/.config/hypr/host.conf (sourced at end of file).
 monitor=,preferred,auto,auto
 
 

--- a/justfile
+++ b/justfile
@@ -93,44 +93,164 @@ unstow package:
 restow package:
     stow -d "{{dotfiles}}" -t "{{home}}" -R {{package}}
 
-# Stow all packages (skips claude, guides, .git)
-stow-all:
-    #!/usr/bin/env bash
-    for pkg in "{{dotfiles}}"/*/; do
-        name=$(basename "$pkg")
-        case "$name" in claude|guides|.git) continue ;; esac
-        stow -d "{{dotfiles}}" -t "{{home}}" "$name"
-    done
-    echo "all packages stowed"
-
-# Full deploy: stow all packages + deploy claude + firefox config
-deploy-all: stow-all claude-deploy firefox-deploy
-
 # ── Bootstrap ────────────────────────────────────────────────────
 
-# Single source of truth for system packages. Add new ones here.
-_pkgs := "hyprland hyprlock hypridle hyprpaper xdg-desktop-portal-hyprland " + \
-         "waybar wofi swaync " + \
-         "pipewire wireplumber pavucontrol libnotify " + \
-         "kitty wezterm-git neovim zsh starship " + \
-         "brightnessctl playerctl hyprshot " + \
-         "jq curl " + \
-         "adw-gtk-theme ttf-firacode-nerd " + \
-         "stow just git " + \
-         "udiskie exfatprogs nautilus " + \
-         "darktable " + \
-         "opencode"
+# Package bundles per type. Add new packages here.
+_pkgs_base := "hyprland hyprlock hypridle hyprpaper xdg-desktop-portal-hyprland " + \
+              "waybar wofi swaync " + \
+              "pipewire wireplumber pavucontrol libnotify " + \
+              "kitty wezterm-git neovim zsh starship " + \
+              "brightnessctl playerctl hyprshot " + \
+              "jq curl " + \
+              "adw-gtk-theme ttf-firacode-nerd " + \
+              "stow just git " + \
+              "udiskie exfatprogs"
 
-# Print the package list, one per line (used by CI to validate names)
-install-deps-list:
-    @echo {{_pkgs}} | tr ' ' '\n'
+_pkgs_production_extras := "firefox nautilus darktable opencode"
+_pkgs_gaming_extras     := "steam"
 
-# Install all system packages this repo configures or references
-install-deps:
-    yay -S --needed {{_pkgs}}
+# Resolve a type → space-separated package list
+_pkgs-for type:
+    #!/usr/bin/env bash
+    case "{{type}}" in
+        base)       echo "{{_pkgs_base}}";;
+        production) echo "{{_pkgs_base}} {{_pkgs_production_extras}}";;
+        gaming)     echo "{{_pkgs_base}} {{_pkgs_gaming_extras}}";;
+        all)        echo "{{_pkgs_base}} {{_pkgs_production_extras}} {{_pkgs_gaming_extras}}";;
+        *) echo "unknown type: {{type}}. Valid: base, production, gaming, all" >&2; exit 1;;
+    esac
 
-# First-time setup: install deps + stow + special-case deploys
-bootstrap: install-deps deploy-all
+# Resolve a type → space-separated stow package list
+_stow-for type:
+    #!/usr/bin/env bash
+    base="hypr waybar wofi kitty wezterm nvim zsh starship gtk udiskie backgrounds"
+    case "{{type}}" in
+        base|gaming)    echo "$base";;
+        production|all) echo "$base gemini opencode";;
+        *) echo "unknown type: {{type}}. Valid: base, production, gaming, all" >&2; exit 1;;
+    esac
+
+# Print resolved package list (used by CI to validate names)
+install-deps-list type="base":
+    @just _pkgs-for {{type}} | tr ' ' '\n'
+
+# Validate the type, required commands, and gaming prerequisites before any
+# install attempt. Fails fast with actionable error messages.
+_preflight type:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    case "{{type}}" in
+        base|production|gaming|all) ;;
+        *) echo "ERROR: unknown type: {{type}}. Valid: base, production, gaming, all" >&2; exit 1;;
+    esac
+    missing=()
+    for cmd in yay git stow; do
+        command -v "$cmd" >/dev/null 2>&1 || missing+=("$cmd")
+    done
+    case "{{type}}" in
+        production|all)
+            command -v curl >/dev/null 2>&1 || missing+=("curl")
+            ;;
+    esac
+    if [ "${#missing[@]}" -ne 0 ]; then
+        echo "ERROR: required commands missing: ${missing[*]}" >&2
+        echo "On Arch: 'sudo pacman -S --needed git base-devel stow curl', then build yay+just from AUR." >&2
+        exit 1
+    fi
+    if [ ! -f "{{dotfiles}}/justfile" ]; then
+        echo "ERROR: dotfiles repo not found at {{dotfiles}}/justfile" >&2
+        exit 1
+    fi
+    case "{{type}}" in
+        gaming|all)
+            if ! grep -qE '^\[multilib\]' /etc/pacman.conf; then
+                echo "ERROR: type={{type}} needs steam, which requires the multilib repo." >&2
+                echo "Enable it: uncomment [multilib] in /etc/pacman.conf, then run 'sudo pacman -Syu'." >&2
+                exit 1
+            fi
+            ;;
+    esac
+    echo "preflight: ok for type={{type}}"
+
+# Install system packages for the given type
+install-deps type="base":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    pkgs=$(just _pkgs-for {{type}})
+    yay -S --needed $pkgs
+
+# Detect host class (laptop|desktop) and symlink the matching host config variant
+host-init:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    mkdir -p "{{home}}/.config/hypr" "{{home}}/.config/waybar"
+    if compgen -G "/sys/class/power_supply/BAT*" > /dev/null 2>&1; then
+        profile=laptop
+    else
+        profile=desktop
+    fi
+    echo "host-init: detected profile=$profile"
+    ln -sfn "{{dotfiles}}/hosts/hypr/host.conf.$profile"    "{{home}}/.config/hypr/host.conf"
+    ln -sfn "{{dotfiles}}/hosts/waybar/host.jsonc.$profile" "{{home}}/.config/waybar/host.jsonc"
+    echo "host-init: linked ~/.config/hypr/host.conf → host.conf.$profile"
+    echo "host-init: linked ~/.config/waybar/host.jsonc → host.jsonc.$profile"
+
+# Stow the stow packages relevant to the type
+stow-all type="base":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    pkgs=$(just _stow-for {{type}})
+    for p in $pkgs; do
+        stow -d "{{dotfiles}}" -t "{{home}}" "$p"
+    done
+    echo "stowed: $pkgs"
+
+# Install Claude Code CLI via the official installer if not already present
+install-claude:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ -x "{{home}}/.local/bin/claude" ]; then
+        echo "install-claude: already installed at {{home}}/.local/bin/claude, skipping"
+        exit 0
+    fi
+    echo "install-claude: running official installer (curl | bash)"
+    curl -fsSL https://claude.ai/install.sh | bash
+
+# Ensure firefox has a default-release profile by launching it briefly headless
+firefox-profile-init:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if compgen -G "$HOME/.mozilla/firefox/*.default-release" > /dev/null 2>&1; then
+        echo "firefox-profile-init: profile already exists, skipping"
+        exit 0
+    fi
+    if ! command -v firefox > /dev/null; then
+        echo "firefox-profile-init: firefox not installed, skipping" >&2
+        exit 0
+    fi
+    echo "firefox-profile-init: launching firefox --headless briefly to create profile"
+    firefox --headless &
+    pid=$!
+    sleep 5
+    kill "$pid" 2>/dev/null || true
+    wait "$pid" 2>/dev/null || true
+
+# Full deploy for the given type
+deploy-all type="base": host-init
+    #!/usr/bin/env bash
+    set -euo pipefail
+    just stow-all {{type}}
+    case "{{type}}" in
+        production|all)
+            just install-claude
+            just claude-deploy
+            just firefox-profile-init
+            just firefox-deploy
+            ;;
+    esac
+
+# First-time setup: preflight + install deps + deploy
+bootstrap type="base": (_preflight type) (install-deps type) (deploy-all type)
     @echo ''
     @echo 'Bootstrap complete. Manual steps remaining:'
     @echo '  1. chsh -s $(which zsh)     # set zsh as default login shell'

--- a/justfile
+++ b/justfile
@@ -95,6 +95,9 @@ restow package:
 
 # ── Bootstrap ────────────────────────────────────────────────────
 
+# git/stow/just/yay must be installed manually before `just bootstrap` can
+# start (see _preflight). They're listed here so subsequent runs keep them
+# updated via yay -S --needed.
 # Package bundles per type. Add new packages here.
 _pkgs_base := "hyprland hyprlock hypridle hyprpaper xdg-desktop-portal-hyprland " + \
               "waybar wofi swaync " + \
@@ -173,11 +176,18 @@ _preflight type:
     echo "preflight: ok for type={{type}}"
 
 # Install system packages for the given type
-install-deps type="base":
+install-deps type="base": (_preflight type)
     #!/usr/bin/env bash
     set -euo pipefail
-    pkgs=$(just _pkgs-for {{type}})
-    yay -S --needed $pkgs
+    case "{{type}}" in
+        base)       pkgs="{{_pkgs_base}}";;
+        production) pkgs="{{_pkgs_base}} {{_pkgs_production_extras}}";;
+        gaming)     pkgs="{{_pkgs_base}} {{_pkgs_gaming_extras}}";;
+        all)        pkgs="{{_pkgs_base}} {{_pkgs_production_extras}} {{_pkgs_gaming_extras}}";;
+        *) echo "unknown type: {{type}}. Valid: base, production, gaming, all" >&2; exit 1;;
+    esac
+    read -ra pkg_arr <<<"$pkgs"
+    yay -S --needed "${pkg_arr[@]}"
 
 # Detect host class (laptop|desktop) and symlink the matching host config variant
 host-init:
@@ -196,11 +206,17 @@ host-init:
     echo "host-init: linked ~/.config/waybar/host.jsonc → host.jsonc.$profile"
 
 # Stow the stow packages relevant to the type
-stow-all type="base":
+stow-bundle type="base":
     #!/usr/bin/env bash
     set -euo pipefail
-    pkgs=$(just _stow-for {{type}})
-    for p in $pkgs; do
+    base="hypr waybar wofi kitty wezterm nvim zsh starship gtk udiskie backgrounds"
+    case "{{type}}" in
+        base|gaming)    pkgs="$base";;
+        production|all) pkgs="$base gemini opencode";;
+        *) echo "unknown type: {{type}}. Valid: base, production, gaming, all" >&2; exit 1;;
+    esac
+    read -ra pkg_arr <<<"$pkgs"
+    for p in "${pkg_arr[@]}"; do
         stow -d "{{dotfiles}}" -t "{{home}}" "$p"
     done
     echo "stowed: $pkgs"
@@ -209,6 +225,10 @@ stow-all type="base":
 install-claude:
     #!/usr/bin/env bash
     set -euo pipefail
+    if [ "${CI:-}" = "true" ]; then
+        echo "install-claude: CI detected, skipping"
+        exit 0
+    fi
     if [ -x "{{home}}/.local/bin/claude" ]; then
         echo "install-claude: already installed at {{home}}/.local/bin/claude, skipping"
         exit 0
@@ -231,15 +251,21 @@ firefox-profile-init:
     echo "firefox-profile-init: launching firefox --headless briefly to create profile"
     firefox --headless &
     pid=$!
-    sleep 5
+    for _ in $(seq 1 30); do
+        compgen -G "$HOME/.mozilla/firefox/*.default-release" >/dev/null 2>&1 && break
+        sleep 1
+    done
     kill "$pid" 2>/dev/null || true
     wait "$pid" 2>/dev/null || true
+    compgen -G "$HOME/.mozilla/firefox/*.default-release" >/dev/null 2>&1 \
+        || { echo "ERROR: firefox-profile-init: profile not created after 30s" >&2; exit 1; }
 
 # Full deploy for the given type
-deploy-all type="base": host-init
+deploy type="base": (_preflight type)
     #!/usr/bin/env bash
     set -euo pipefail
-    just stow-all {{type}}
+    just stow-bundle {{type}}
+    just host-init
     case "{{type}}" in
         production|all)
             just install-claude
@@ -250,7 +276,7 @@ deploy-all type="base": host-init
     esac
 
 # First-time setup: preflight + install deps + deploy
-bootstrap type="base": (_preflight type) (install-deps type) (deploy-all type)
+bootstrap type="base": (_preflight type) (install-deps type) (deploy type)
     @echo ''
     @echo 'Bootstrap complete. Manual steps remaining:'
     @echo '  1. chsh -s $(which zsh)     # set zsh as default login shell'

--- a/justfile
+++ b/justfile
@@ -81,17 +81,27 @@ firefox-deploy:
 
 # ── Stow wrappers ─────────────────────────────────────────────────
 
-# Stow a single package
+# Stow a single package (auto-runs host-init for hypr/waybar)
 stow package:
+    #!/usr/bin/env bash
+    set -euo pipefail
     stow -d "{{dotfiles}}" -t "{{home}}" {{package}}
+    case "{{package}}" in
+        hypr|waybar) just host-init ;;
+    esac
 
 # Unstow a single package
 unstow package:
     stow -d "{{dotfiles}}" -t "{{home}}" -D {{package}}
 
-# Restow a package (unstow + stow)
+# Restow a package: unstow + stow (auto-runs host-init for hypr/waybar)
 restow package:
+    #!/usr/bin/env bash
+    set -euo pipefail
     stow -d "{{dotfiles}}" -t "{{home}}" -R {{package}}
+    case "{{package}}" in
+        hypr|waybar) just host-init ;;
+    esac
 
 # ── Bootstrap ────────────────────────────────────────────────────
 
@@ -120,16 +130,6 @@ _pkgs-for type:
         production) echo "{{_pkgs_base}} {{_pkgs_production_extras}}";;
         gaming)     echo "{{_pkgs_base}} {{_pkgs_gaming_extras}}";;
         all)        echo "{{_pkgs_base}} {{_pkgs_production_extras}} {{_pkgs_gaming_extras}}";;
-        *) echo "unknown type: {{type}}. Valid: base, production, gaming, all" >&2; exit 1;;
-    esac
-
-# Resolve a type → space-separated stow package list
-_stow-for type:
-    #!/usr/bin/env bash
-    base="hypr waybar wofi kitty wezterm nvim zsh starship gtk udiskie backgrounds"
-    case "{{type}}" in
-        base|gaming)    echo "$base";;
-        production|all) echo "$base gemini opencode";;
         *) echo "unknown type: {{type}}. Valid: base, production, gaming, all" >&2; exit 1;;
     esac
 
@@ -245,8 +245,10 @@ firefox-profile-init:
         exit 0
     fi
     if ! command -v firefox > /dev/null; then
-        echo "firefox-profile-init: firefox not installed, skipping" >&2
-        exit 0
+        echo "ERROR: firefox-profile-init: firefox not installed." >&2
+        echo "  This recipe runs only via the production/all deploy path," >&2
+        echo "  which should have installed firefox via install-deps." >&2
+        exit 1
     fi
     echo "firefox-profile-init: launching firefox --headless briefly to create profile"
     firefox --headless &

--- a/waybar/.config/waybar/config.jsonc
+++ b/waybar/.config/waybar/config.jsonc
@@ -1,5 +1,9 @@
 // -*- mode: jsonc -*-
 {
+    // Per-host overrides (modules-right + battery/backlight modules on laptop)
+    // live in ~/.config/waybar/host.jsonc, symlinked by `just host-init`.
+    // See guides/host-config.md.
+    "include": ["~/.config/waybar/host.jsonc"],
     // "layer": "top", // Waybar at top layer
     "position": "top", // Waybar position (top|bottom|left|right)
     // "height": 30, // Waybar height (to be removed for auto height)
@@ -17,25 +21,7 @@
         // "hyprland/window",
         "clock"
     ],
-    "modules-right": [
-        // "mpd",
-        // "idle_inhibitor",
-        // "custom/weather",
-        "custom/udiskie",
-        "custom/swaync",
-        "pulseaudio",
-        // "power-profiles-daemon",
-        // "keyboard-state",
-        "cpu",
-        "memory",
-        "temperature",
-        "backlight",
-        "network",
-        "battery"
-        // "battery#bat2",
-        // "clock"
-        // "custom/power"
-    ],
+    // modules-right is defined per-host in host.jsonc (see "include" above).
     // Modules configuration
     // "hyprland/workspaces": {
     //      "disable-scroll": true,
@@ -142,38 +128,7 @@
         "format-icons": ["", "", ""],
         "format-alt": "<span size='13000'>{icon} </span> {temperatureF}°F",
     },
-    "backlight": {
-        // "device": "acpi_video1",
-        // "format": "{percent}% {icon}",
-        "format": "<span size='13000'>{icon} </span> {percent}% ",
-        "tooltip-format": "{percent}%",
-        "format-icons": ["", "", "", "", "", "", "", "", ""]
-    },
-    "battery": {
-        "states": {
-            // "good": 95,
-            "warning": 30,
-            "critical": 15,
-        },
-        // "format": "{capacity}% {icon}",
-        // "format-full": "{capacity}% {icon}",
-        // "format-charging": "{capacity}% ",
-        // "format-plugged": "{capacity}% ",
-        // "format-alt": "{time} {icon}",
-        // // "format-good": "", // An empty format will hide the module
-        // // "format-full": "",
-        // "format-icons": ["", "", "", "", ""]
-        "format": "<span size='13000'>{icon} </span> {capacity}%",
-        "format-alt": "<span size='13000'>{icon} </span> {time}",
-        "format-full": "<span size='13000'> </span>{capacity}%",
-        "format-warning": "<span size='13000'>{icon} </span> {capacity}%",
-        "format-critical": "<span size='13000'>{icon} </span> {capacity}%",
-        "format-charging": "<span size='13000'> </span>{capacity}%",
-        "format-plugged": "<span size='13000'> </span>{capacity}%",
-        "format-full": "<span size='13000'> </span>{capacity}%",
-        "format-icons": ["", "", "", "", ""],
-        "tooltip-format": "{time}"
-    },
+    // backlight + battery modules (laptop-only) live in host.jsonc.laptop.
     // "battery#bat2": {
     //     "bat": "BAT2"
     // },

--- a/waybar/.config/waybar/config.jsonc
+++ b/waybar/.config/waybar/config.jsonc
@@ -129,20 +129,6 @@
         "format-alt": "<span size='13000'>{icon} </span> {temperatureF}°F",
     },
     // backlight + battery modules (laptop-only) live in host.jsonc.laptop.
-    // "battery#bat2": {
-    //     "bat": "BAT2"
-    // },
-    // "power-profiles-daemon": {
-    //   "format": "{icon}",
-    //   "tooltip-format": "Power profile: {profile}\nDriver: {driver}",
-    //   "tooltip": true,
-    //   "format-icons": {
-    //     "default": "",
-    //     "performance": "",
-    //     "balanced": "",
-    //     "power-saver": ""
-    //   }
-    // },
     "network": {
         // "interface": "wlp2*", // (Optional) To force the use of this interface
         // "format-wifi": "<span size='13000'> </span>{essid} ({signalStrength}%) ",


### PR DESCRIPTION
update the bootstrap to work on a new desktop machine that does not have gnome as a backup for hypr.

this caused a bunch of weirdness since the bootstrap needed to handle different goals for setups and now puts a bunch of packages and apps on a machine. which is not always desired.

left to do is actually test on the pc. we'll have to touch this again for the server setup since we just want headless base packages anyway. if my machine goes down, pretty quick to setup now off the bootstrap.