### PR TITLE
fix(bootstrap): resolve fresh-install bugs + hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,13 @@ positional argument to install more — e.g. `just bootstrap all`. See
 [`guides/host-config.md`](guides/host-config.md) for what each bundle includes
 and how the laptop/desktop autodetect works.
 
+Bootstrap also makes a few system-level changes after the package install:
+sets the login shell to zsh, enables `udisks2` (for the udiskie automount
+tray), and on machines without a display manager it configures TTY1
+autologin and hardens sshd (drop-in disabling password auth + root password
+login, if sshd is active). See
+[`guides/host-config.md`](guides/host-config.md) for the boot model.
+
 ## Day-to-day commands
 
 ```zsh

--- a/README.md
+++ b/README.md
@@ -58,9 +58,10 @@ cd ~/.dotfiles
 just bootstrap
 ```
 
-Defaults to the `base` bundle. Pass `type=production|gaming|all` to install
-more — see [`guides/host-config.md`](guides/host-config.md) for what each
-bundle includes and how the laptop/desktop autodetect works.
+Defaults to the `base` bundle. Pass `production`, `gaming`, or `all` as a
+positional argument to install more — e.g. `just bootstrap all`. See
+[`guides/host-config.md`](guides/host-config.md) for what each bundle includes
+and how the laptop/desktop autodetect works.
 
 ## Day-to-day commands
 

--- a/guides/arch.md
+++ b/guides/arch.md
@@ -2,16 +2,13 @@
 
 ## nvim
 
+The dotfiles' `.zshrc` and `.zprofile` already source pyenv if it's on
+PATH (guarded by `command -v pyenv`), so just install pyenv plus the
+support tools nvim needs, then re-source your shell:
+
 ```zsh
-yay -Suy wget pyenv pyenv-virtualenv npm ripgrep fd-find fzf python-pip
+yay -S --needed wget pyenv pyenv-virtualenv npm ripgrep fd fzf python-pip
 npm install -g tree-sitter-cli
-echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.zshrc
-echo '[[ -d $PYENV_ROOT/bin ]] && export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.zshrc
-echo 'eval "$(pyenv init - zsh)"' >> ~/.zshrc
-echo 'eval "$(pyenv virtualenv-init -)" >> ~/.zshrc
-echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.zprofile
-echo '[[ -d $PYENV_ROOT/bin ]] && export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.zprofile
-echo 'eval "$(pyenv init - zsh)"' >> ~/.zprofile
 exec "$SHELL"
 pyenv virtualenv neovim
 ```

--- a/guides/arch.md
+++ b/guides/arch.md
@@ -7,7 +7,7 @@ PATH (guarded by `command -v pyenv`), so just install pyenv plus the
 support tools nvim needs, then re-source your shell:
 
 ```zsh
-yay -S --needed wget pyenv pyenv-virtualenv npm ripgrep fd fzf python-pip
+yay -Suy wget pyenv pyenv-virtualenv npm ripgrep fd fzf python-pip
 npm install -g tree-sitter-cli
 exec "$SHELL"
 pyenv virtualenv neovim

--- a/guides/host-config.md
+++ b/guides/host-config.md
@@ -7,7 +7,7 @@ typed bootstrap (chooses *what* to install) and host autodetect (chooses
 ## Typed bootstrap
 
 ```zsh
-just bootstrap type=<base|production|gaming|all>
+just bootstrap <base|production|gaming|all>
 ```
 
 | Type         | System packages                                                | Stow packages                          |
@@ -57,7 +57,7 @@ the desktop branch and the symlink mechanics.
 
 CI tests the `base` type only. Production-specific recipes (`claude-deploy`,
 `firefox-deploy`, `install-claude`, `firefox-profile-init`) are exercised
-manually via `just bootstrap type=production` on real hardware — see the
+manually via `just bootstrap production` on real hardware — see the
 verification section of any change that touches them.
 
 ## Force-overriding the autodetect

--- a/guides/host-config.md
+++ b/guides/host-config.md
@@ -20,9 +20,15 @@ just bootstrap <base|production|gaming|all>
 `just bootstrap` with no argument defaults to `base`.
 
 `production` and `all` additionally run `install-claude` (curl installer),
-`claude-deploy` (copy claude/ config), `firefox-profile-init` (launch
-firefox headless once to seed a default profile), and `firefox-deploy`
-(symlink chrome/ into the profile).
+`claude-deploy` (copy claude/ config), and `firefox-deploy` (symlink
+chrome/ into the firefox profile).
+
+Firefox itself needs a one-time manual step: launch firefox interactively
+once from inside Hyprland so it seeds a `default-release` profile, then
+re-run `just firefox-deploy` to install the userChrome symlink. Bootstrap
+intentionally doesn't try to headless-init the profile — Firefox 67+'s
+profile-per-install lock rejects empty `-CreateProfile` dirs on first
+launch, and `--headless` first-run has been flaky across versions.
 
 `gaming` and `all` require the `[multilib]` repo enabled in
 `/etc/pacman.conf` (steam pulls lib32-* dependencies). `_preflight` checks
@@ -56,9 +62,9 @@ The laptop branch is exercised only by manual runs on a laptop; CI covers
 the desktop branch and the symlink mechanics.
 
 CI tests the `base` type only. Production-specific recipes (`claude-deploy`,
-`firefox-deploy`, `install-claude`, `firefox-profile-init`) are exercised
-manually via `just bootstrap production` on real hardware — see the
-verification section of any change that touches them.
+`firefox-deploy`, `install-claude`) are exercised manually via
+`just bootstrap production` on real hardware — see the verification section
+of any change that touches them.
 
 ## Force-overriding the autodetect
 

--- a/guides/host-config.md
+++ b/guides/host-config.md
@@ -34,6 +34,15 @@ launch, and `--headless` first-run has been flaky across versions.
 `/etc/pacman.conf` (steam pulls lib32-* dependencies). `_preflight` checks
 this before any install.
 
+A few packages in the `base` bundle are load-bearing for the shipped
+shell + login flow rather than incidental tooling — removing them from
+`_pkgs_base` will break the corresponding alias or security guarantee:
+
+- `eza` — backs the `ls` alias in `.zshrc`
+- `arch-update` — backs the `update` / `news` aliases in `.zshrc`
+- `vlock` — locks TTY1 if Hyprland exits, preventing exposure of the
+  autologged-in shell (see `~/.zlogin`)
+
 ## Per-host autodetect
 
 `just host-init` (also run automatically as part of `deploy`) detects

--- a/guides/host-config.md
+++ b/guides/host-config.md
@@ -43,6 +43,31 @@ shell + login flow rather than incidental tooling — removing them from
 - `vlock` — locks TTY1 if Hyprland exits, preventing exposure of the
   autologged-in shell (see `~/.zlogin`)
 
+## Boot model (no display manager)
+
+On hosts without a display manager (`sddm`/`gdm`/`greetd`/`ly`/`lightdm`),
+bootstrap wires up a single-auth boot flow via three coordinated pieces:
+
+1. `just enable-tty-autologin` writes
+   `/etc/systemd/system/getty@tty1.service.d/autologin.conf` so TTY1 boots
+   straight to a logged-in shell. Skipped if a display manager is enabled
+   (DM owns the boot path). Refuses to run as root to prevent baking
+   `--autologin root` into the override.
+2. `~/.zlogin` (zsh login-shell hook) gates on `/dev/tty1` and execs
+   `start-hyprland`. On Hyprland exit it execs `vlock` to lock the VT so
+   the autologged-in shell isn't exposed. A `HYPRLAND_LAUNCH_GUARD` env
+   prevents a tight loop in the pathological case where both Hyprland and
+   vlock are missing.
+3. `hosts/hypr/host.conf.desktop` sets `exec-once = hyprlock` so the
+   desktop boots straight into a locked screen — hyprlock becomes the
+   single auth gate.
+
+`just harden-sshd` (also run by `bootstrap` when sshd is active or enabled)
+drops `99-dotfiles-hardening.conf` into `/etc/ssh/sshd_config.d/` to
+disable `PasswordAuthentication` and root-password login. The drop-in is
+written to a tempfile, validated with `sshd -t`, then `mv`'d into place,
+so a broken config never lands.
+
 ## Per-host autodetect
 
 `just host-init` (also run automatically as part of `deploy`) detects
@@ -53,7 +78,7 @@ and symlinks the matching variant from `hosts/`:
 hosts/
 ├── hypr/
 │   ├── host.conf.laptop     # eDP-1 monitor, brightness keybinds
-│   └── host.conf.desktop    # empty (catch-all monitor= already covers it)
+│   └── host.conf.desktop    # exec-once = hyprlock (lock-at-boot for no-DM hosts)
 └── waybar/
     ├── host.jsonc.laptop    # modules-right with battery + backlight
     └── host.jsonc.desktop   # modules-right without battery/backlight

--- a/hosts/hypr/host.conf.desktop
+++ b/hosts/hypr/host.conf.desktop
@@ -1,3 +1,8 @@
 # Desktop Hyprland overrides. Symlinked into place by `just host-init`
-# when no battery is detected. Intentionally empty — the catch-all
+# when no battery is detected. The catch-all
 # `monitor=,preferred,auto,auto` in hyprland.conf covers desktop monitors.
+
+# Lock immediately on Hyprland launch. Desktop hosts use TTY1 autologin
+# (see `enable-tty-autologin` in justfile) instead of a display manager,
+# so hyprlock is the single auth gate at boot.
+exec-once = hyprlock

--- a/hypr/.config/hypr/hyprland.conf
+++ b/hypr/.config/hypr/hyprland.conf
@@ -56,7 +56,16 @@ $diskmanager = udiskie
 # exec-once = $terminal
 # exec-once = nm-applet &
 # exec-once = waybar & hyprpaper & firefox
-exec-once = $bar & $menu & $idle & $paper & $diskmanager
+# One exec-once per app (clearer than the old `cmd1 & cmd2 & ...` chain,
+# and avoids whole-line failures if one entry misbehaves).
+# `$paper` (hyprpaper) needs a small delay: as of hyprpaper 0.8.x its
+# hyprtoolkit-based startup fails fast on `wl_display_connect` if the
+# wayland socket isn't fully ready when exec-once fires — repros on no-DM
+# desktops via TTY1 autologin → start-hyprland. A 1s sleep wins the race.
+exec-once = $bar
+exec-once = $idle
+exec-once = sleep 1 && $paper
+exec-once = $diskmanager
 # exec-once=dbus-update-activation-environment --systemd WAYLAND_DISPLAY XDG_CURRENT_DESKTOP
 exec = gsettings set org.gnome.desktop.interface gtk-theme 'adw-gtk3-dark'
 exec = gsettings set org.gnome.desktop.interface color-scheme 'prefer-dark'

--- a/hypr/.config/hypr/hyprland.conf
+++ b/hypr/.config/hypr/hyprland.conf
@@ -58,13 +58,15 @@ $diskmanager = udiskie
 # exec-once = waybar & hyprpaper & firefox
 # One exec-once per app (clearer than the old `cmd1 & cmd2 & ...` chain,
 # and avoids whole-line failures if one entry misbehaves).
-# `$paper` (hyprpaper) needs a small delay: as of hyprpaper 0.8.x its
+# `hyprpaper` is wrapped in a bash wait-loop: as of hyprpaper 0.8.x its
 # hyprtoolkit-based startup fails fast on `wl_display_connect` if the
 # wayland socket isn't fully ready when exec-once fires — repros on no-DM
-# desktops via TTY1 autologin → start-hyprland. A 1s sleep wins the race.
+# desktops via TTY1 autologin → start-hyprland. Polling the socket via
+# `$XDG_RUNTIME_DIR/$WAYLAND_DISPLAY` is more robust than a fixed sleep
+# (race is hardware-dependent) and multi-instance safe.
 exec-once = $bar
 exec-once = $idle
-exec-once = sleep 1 && $paper
+exec-once = bash -c 'until [ -S "$XDG_RUNTIME_DIR/$WAYLAND_DISPLAY" ]; do sleep 0.1; done; hyprpaper'
 exec-once = $diskmanager
 # exec-once=dbus-update-activation-environment --systemd WAYLAND_DISPLAY XDG_CURRENT_DESKTOP
 exec = gsettings set org.gnome.desktop.interface gtk-theme 'adw-gtk3-dark'

--- a/hypr/.config/hypr/hyprpaper.conf
+++ b/hypr/.config/hypr/hyprpaper.conf
@@ -1,8 +1,21 @@
 # Portable across users: ~ expands per-user. Stowed `backgrounds/` package
-# places the image at ~/.config/backgrounds/. Traditional `preload + wallpaper`
-# syntax used over the newer `wallpaper { }` block — the block form's
-# auto-preload behavior is version-dependent and silently does nothing on
-# older hyprpaper builds.
+# places the image at ~/.config/backgrounds/.
+#
+# Explicit `preload =` is required regardless of which wallpaper syntax we
+# use (a wallpaper cannot be applied without first being preloaded). The
+# `wallpaper { }` block form is used because:
+#   - `fit_mode = contain` is only honored in block syntax
+#   - the traditional `wallpaper = monitor,path` form's "mode prefix" pattern
+#     (e.g. `,contain:path`) is misparsed as a literal path and triggers
+#     "no target so no wp will be created" on multi-monitor hosts
+#   - `monitor =` (empty) in block form is the documented fallback for
+#     every monitor that doesn't have a specific assignment
 preload = ~/.config/backgrounds/Gemini_Generated_Image_hsu92jhsu92jhsu9.png
-wallpaper = ,contain:~/.config/backgrounds/Gemini_Generated_Image_hsu92jhsu92jhsu9.png
+
+wallpaper {
+    monitor =
+    path = ~/.config/backgrounds/Gemini_Generated_Image_hsu92jhsu92jhsu9.png
+    fit_mode = contain
+}
+
 splash = false

--- a/hypr/.config/hypr/hyprpaper.conf
+++ b/hypr/.config/hypr/hyprpaper.conf
@@ -1,6 +1,8 @@
-wallpaper {
-    monitor =
-    path = /home/anotherjson/.config/backgrounds/Gemini_Generated_Image_hsu92jhsu92jhsu9.png
-    fit_mode = contain
-}
+# Portable across users: ~ expands per-user. Stowed `backgrounds/` package
+# places the image at ~/.config/backgrounds/. Traditional `preload + wallpaper`
+# syntax used over the newer `wallpaper { }` block — the block form's
+# auto-preload behavior is version-dependent and silently does nothing on
+# older hyprpaper builds.
+preload = ~/.config/backgrounds/Gemini_Generated_Image_hsu92jhsu92jhsu9.png
+wallpaper = ,contain:~/.config/backgrounds/Gemini_Generated_Image_hsu92jhsu92jhsu9.png
 splash = false

--- a/justfile
+++ b/justfile
@@ -74,8 +74,15 @@ claude-status:
 # Link firefox/chrome/ into the active Firefox profile
 firefox-deploy:
     #!/usr/bin/env bash
-    profile=$(find ~/.mozilla/firefox -maxdepth 1 -name "*.default-release" -type d | head -1)
-    if [ -z "$profile" ]; then echo "no firefox profile found"; exit 1; fi
+    profile=$(find ~/.mozilla/firefox -maxdepth 1 -name "*.default-release" -type d 2>/dev/null | head -1)
+    if [ -z "$profile" ]; then
+        if [ -z "${DISPLAY:-}" ] && [ -z "${WAYLAND_DISPLAY:-}" ]; then
+            echo "firefox-deploy: no profile yet AND no graphical session — skipping."
+            echo "  Re-run from inside Hyprland: 'just firefox-profile-init && just firefox-deploy'"
+            exit 0
+        fi
+        echo "no firefox profile found"; exit 1
+    fi
     ln -sfn "{{dotfiles}}/firefox/chrome" "$profile/chrome"
     echo "firefox chrome/ linked to $profile/chrome"
 
@@ -249,6 +256,12 @@ firefox-profile-init:
     set -euo pipefail
     if compgen -G "$HOME/.mozilla/firefox/*.default-release" > /dev/null 2>&1; then
         echo "firefox-profile-init: profile already exists, skipping"
+        exit 0
+    fi
+    if [ -z "${DISPLAY:-}" ] && [ -z "${WAYLAND_DISPLAY:-}" ]; then
+        echo "firefox-profile-init: no graphical session (DISPLAY/WAYLAND_DISPLAY unset)."
+        echo "  firefox --headless still needs DRM + session bus; skipping for now."
+        echo "  Re-run from inside Hyprland: 'just firefox-profile-init && just firefox-deploy'"
         exit 0
     fi
     if ! command -v firefox > /dev/null; then

--- a/justfile
+++ b/justfile
@@ -329,6 +329,56 @@ harden-sshd:
     }
     echo "harden-sshd: wrote $drop, sshd reloaded"
 
+# Diagnose hyprpaper not displaying wallpaper. Run on the affected host.
+# Read-only; no system modifications. Save with redirect for sharing:
+#   just diagnose-hyprpaper > /tmp/hyprpaper-diag.txt 2>&1
+diagnose-hyprpaper:
+    #!/usr/bin/env bash
+    set +e
+    echo "=== hyprpaper version ==="
+    yay -Qi hyprpaper 2>/dev/null | grep -E '^(Name|Version)' || echo "not installed"
+    echo
+    echo "=== config file (~/.config/hypr/hyprpaper.conf) ==="
+    if [ -L ~/.config/hypr/hyprpaper.conf ]; then
+        echo "symlink → $(readlink -f ~/.config/hypr/hyprpaper.conf)"
+    elif [ -f ~/.config/hypr/hyprpaper.conf ]; then
+        echo "regular file"
+    else
+        echo "MISSING"
+    fi
+    cat ~/.config/hypr/hyprpaper.conf 2>/dev/null
+    echo
+    echo "=== wallpaper file resolution ==="
+    echo "\$HOME = $HOME"
+    echo "expanded path = $HOME/.config/backgrounds/Gemini_Generated_Image_hsu92jhsu92jhsu9.png"
+    ls -lL "$HOME/.config/backgrounds/" 2>&1 | head -10
+    echo
+    echo "=== exec-once chain processes (the smoking gun) ==="
+    echo "If any of these are missing, the hyprland.conf:59 chain failed somewhere."
+    for proc in waybar wofi hypridle hyprpaper udiskie hyprlock; do
+        if pgrep -x "$proc" >/dev/null 2>&1; then
+            echo "  RUNNING:  $proc ($(pgrep -x $proc | tr '\n' ',' | sed 's/,$//'))"
+        else
+            echo "  MISSING:  $proc"
+        fi
+    done
+    echo
+    echo "=== host.conf symlink target (desktop vs laptop variant) ==="
+    if [ -L ~/.config/hypr/host.conf ]; then
+        echo "→ $(readlink -f ~/.config/hypr/host.conf)"
+    else
+        echo "NOT A SYMLINK or MISSING"
+    fi
+    echo
+    echo "=== hyprctl hyprpaper state ==="
+    hyprctl hyprpaper listactive 2>&1
+    echo
+    echo "=== connected monitors ==="
+    hyprctl monitors 2>&1 | grep -E '^(Monitor|	description)' | head -20
+    echo
+    echo "=== journal: 'paper' lines (last 10 minutes) ==="
+    journalctl --user --since "10 minutes ago" 2>/dev/null | grep -i paper | tail -50
+
 # First-time setup. Runs preflight → install-deps → deploy, then
 # system-level activation: chsh to zsh, enable udisks2, configure TTY1
 # autologin (no-DM hosts), harden sshd (if active). sudo cache is primed

--- a/justfile
+++ b/justfile
@@ -311,7 +311,7 @@ harden-sshd:
     fi
     drop=/etc/ssh/sshd_config.d/99-dotfiles-hardening.conf
     sudo mkdir -p /etc/ssh/sshd_config.d
-    tmp=$(sudo mktemp /etc/ssh/sshd_config.d/.99-dotfiles-hardening.XXXXXX)
+    tmp=$(sudo mktemp --suffix=.conf /etc/ssh/sshd_config.d/99-dotfiles-hardening.XXXXXX)
     sudo tee "$tmp" > /dev/null <<EOF
     # Managed by anotherdot dotfiles (justfile harden-sshd recipe).
     PasswordAuthentication no

--- a/justfile
+++ b/justfile
@@ -272,7 +272,5 @@ bootstrap type="base": (_preflight type) (install-deps type) (deploy type)
     @sudo systemctl enable --now udisks2
     @echo ''
     @echo 'Bootstrap complete. Manual steps remaining:'
-    @echo '  1. Reload Hyprland (Super+Shift+C) to apply config'
-    @echo '  2. Log out and back in once — for GTK theme to fully apply AND for the new zsh login shell to take effect'
-    @echo '  3. Open a new shell so .zshrc loads (dots alias becomes available)'
-    @echo '  4. (production|all only) launch firefox once from Hyprland, then `just firefox-deploy` to install userChrome'
+    @echo '  1. Restart your session (log out + back in, or reboot) to apply configs — login shell, Hyprland, GTK theme, .zshrc env'
+    @echo '  2. (production|all only) launch firefox once from Hyprland, then `just firefox-deploy` to install userChrome'

--- a/justfile
+++ b/justfile
@@ -76,12 +76,11 @@ firefox-deploy:
     #!/usr/bin/env bash
     profile=$(find ~/.mozilla/firefox -maxdepth 1 -name "*.default-release" -type d 2>/dev/null | head -1)
     if [ -z "$profile" ]; then
-        if [ -z "${DISPLAY:-}" ] && [ -z "${WAYLAND_DISPLAY:-}" ]; then
-            echo "firefox-deploy: no profile yet AND no graphical session — skipping."
-            echo "  Re-run from inside Hyprland: 'just firefox-profile-init && just firefox-deploy'"
-            exit 0
-        fi
-        echo "no firefox profile found"; exit 1
+        echo "firefox-deploy: no default-release profile found in ~/.mozilla/firefox/."
+        echo "  Launch firefox once interactively (from Hyprland) to seed a profile,"
+        echo "  then re-run: 'just firefox-deploy'."
+        echo "  Skipping for now — bootstrap can continue."
+        exit 0
     fi
     ln -sfn "{{dotfiles}}/firefox/chrome" "$profile/chrome"
     echo "firefox chrome/ linked to $profile/chrome"
@@ -250,38 +249,6 @@ install-claude:
     echo "install-claude: running official installer (curl | bash)"
     curl -fsSL https://claude.ai/install.sh | bash
 
-# Ensure firefox has a default-release profile by launching it briefly headless
-firefox-profile-init:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    if compgen -G "$HOME/.mozilla/firefox/*.default-release" > /dev/null 2>&1; then
-        echo "firefox-profile-init: profile already exists, skipping"
-        exit 0
-    fi
-    if [ -z "${DISPLAY:-}" ] && [ -z "${WAYLAND_DISPLAY:-}" ]; then
-        echo "firefox-profile-init: no graphical session (DISPLAY/WAYLAND_DISPLAY unset)."
-        echo "  firefox --headless still needs DRM + session bus; skipping for now."
-        echo "  Re-run from inside Hyprland: 'just firefox-profile-init && just firefox-deploy'"
-        exit 0
-    fi
-    if ! command -v firefox > /dev/null; then
-        echo "ERROR: firefox-profile-init: firefox not installed." >&2
-        echo "  This recipe runs only via the production/all deploy path," >&2
-        echo "  which should have installed firefox via install-deps." >&2
-        exit 1
-    fi
-    echo "firefox-profile-init: launching firefox --headless briefly to create profile"
-    firefox --headless &
-    pid=$!
-    for _ in $(seq 1 30); do
-        compgen -G "$HOME/.mozilla/firefox/*.default-release" >/dev/null 2>&1 && break
-        sleep 1
-    done
-    kill "$pid" 2>/dev/null || true
-    wait "$pid" 2>/dev/null || true
-    compgen -G "$HOME/.mozilla/firefox/*.default-release" >/dev/null 2>&1 \
-        || { echo "ERROR: firefox-profile-init: profile not created after 30s" >&2; exit 1; }
-
 # Full deploy for the given type
 deploy type="base": (_preflight type)
     #!/usr/bin/env bash
@@ -292,7 +259,6 @@ deploy type="base": (_preflight type)
         production|all)
             just install-claude
             just claude-deploy
-            just firefox-profile-init
             just firefox-deploy
             ;;
     esac
@@ -306,3 +272,4 @@ bootstrap type="base": (_preflight type) (install-deps type) (deploy type)
     @echo '  3. Log out and back in once for GTK theme to fully apply'
     @echo '  4. Open a new shell so .zshrc loads (dots alias becomes available)'
     @echo '  5. sudo systemctl enable --now udisks2     # enable removable-media automount for udiskie'
+    @echo '  6. (production|all only) launch firefox once from Hyprland, then `just firefox-deploy` to install userChrome'

--- a/justfile
+++ b/justfile
@@ -120,7 +120,7 @@ _pkgs_base := "hyprland hyprlock hypridle hyprpaper xdg-desktop-portal-hyprland 
               "pipewire wireplumber pavucontrol libnotify " + \
               "kitty wezterm-git neovim zsh starship " + \
               "brightnessctl playerctl hyprshot " + \
-              "eza jq curl arch-update " + \
+              "eza jq curl arch-update vlock " + \
               "adw-gtk-theme ttf-firacode-nerd " + \
               "stow just git " + \
               "udiskie exfatprogs"
@@ -286,6 +286,29 @@ enable-tty-autologin:
     sudo systemctl daemon-reload
     echo "enable-tty-autologin: wrote $override_file"
 
+# Drop in `sshd_config.d/99-dotfiles-hardening.conf` to disable password
+# auth and root password login. Skipped if sshd is neither enabled nor
+# active (no point hardening a service that isn't running). Uses a
+# drop-in so pacman updates to /etc/ssh/sshd_config don't clobber it.
+harden-sshd:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if ! systemctl is-enabled sshd >/dev/null 2>&1 \
+        && ! systemctl is-active sshd >/dev/null 2>&1; then
+        echo "harden-sshd: sshd not enabled or active, skipping."
+        exit 0
+    fi
+    drop=/etc/ssh/sshd_config.d/99-dotfiles-hardening.conf
+    sudo mkdir -p /etc/ssh/sshd_config.d
+    sudo tee "$drop" > /dev/null <<EOF
+    # Managed by anotherdot dotfiles (justfile harden-sshd recipe).
+    PasswordAuthentication no
+    PermitRootLogin prohibit-password
+    EOF
+    sudo sshd -t
+    sudo systemctl reload sshd 2>/dev/null || sudo systemctl restart sshd
+    echo "harden-sshd: wrote $drop, sshd reloaded"
+
 # First-time setup: preflight + install deps + deploy
 bootstrap type="base": (_preflight type) (install-deps type) (deploy type)
     @echo ''
@@ -294,6 +317,7 @@ bootstrap type="base": (_preflight type) (install-deps type) (deploy type)
     @echo 'Enabling udisks2 (system service that udiskie listens to for automount)...'
     @sudo systemctl enable --now udisks2
     @just enable-tty-autologin
+    @just harden-sshd
     @echo ''
     @echo 'Bootstrap complete. Manual steps remaining:'
     @echo '  1. Restart your session (log out + back in, or reboot) to apply configs — login shell, Hyprland, GTK theme, .zshrc env'

--- a/justfile
+++ b/justfile
@@ -120,7 +120,7 @@ _pkgs_base := "hyprland hyprlock hypridle hyprpaper xdg-desktop-portal-hyprland 
               "pipewire wireplumber pavucontrol libnotify " + \
               "kitty wezterm-git neovim zsh starship " + \
               "brightnessctl playerctl hyprshot " + \
-              "eza jq curl " + \
+              "eza jq curl arch-update " + \
               "adw-gtk-theme ttf-firacode-nerd " + \
               "stow just git " + \
               "udiskie exfatprogs"

--- a/justfile
+++ b/justfile
@@ -121,7 +121,7 @@ _pkgs_base := "hyprland hyprlock hypridle hyprpaper xdg-desktop-portal-hyprland 
               "pipewire wireplumber pavucontrol libnotify " + \
               "kitty wezterm-git neovim zsh starship " + \
               "brightnessctl playerctl hyprshot " + \
-              "eza jq curl arch-update vlock " + \
+              "eza jq curl arch-update " + \
               "adw-gtk-theme ttf-firacode-nerd " + \
               "stow just git " + \
               "udiskie exfatprogs"

--- a/justfile
+++ b/justfile
@@ -154,7 +154,10 @@ _preflight type:
             echo "Use positional form: just bootstrap <base|production|gaming|all>" >&2
             exit 1;;
         base|production|gaming|all) ;;
-        *) echo "ERROR: unknown type: {{type}}. Valid: base, production, gaming, all" >&2; exit 1;;
+        *)
+            echo "ERROR: unknown type: {{type}}. Valid: base, production, gaming, all" >&2
+            echo "  e.g. just bootstrap production" >&2
+            exit 1;;
     esac
     missing=()
     for cmd in yay git; do
@@ -275,13 +278,20 @@ enable-tty-autologin:
         echo "enable-tty-autologin: display manager is enabled, skipping autologin override."
         exit 0
     fi
+    user="${SUDO_USER:-$USER}"
+    if [[ "$user" == "root" ]]; then
+        echo "ERROR: refusing to configure root autologin." >&2
+        echo "  Run as a regular user without sudo: 'just bootstrap'." >&2
+        exit 1
+    fi
+    echo "enable-tty-autologin: configuring TTY1 autologin for user=$user"
     override_dir=/etc/systemd/system/getty@tty1.service.d
     override_file="$override_dir/autologin.conf"
     sudo mkdir -p "$override_dir"
     sudo tee "$override_file" > /dev/null <<EOF
     [Service]
     ExecStart=
-    ExecStart=-/usr/bin/agetty --autologin $USER --noclear %I \$TERM
+    ExecStart=-/usr/bin/agetty --autologin $user --noclear %I \$TERM
     EOF
     sudo systemctl daemon-reload
     echo "enable-tty-autologin: wrote $override_file"
@@ -300,20 +310,33 @@ harden-sshd:
     fi
     drop=/etc/ssh/sshd_config.d/99-dotfiles-hardening.conf
     sudo mkdir -p /etc/ssh/sshd_config.d
-    sudo tee "$drop" > /dev/null <<EOF
+    tmp=$(sudo mktemp /etc/ssh/sshd_config.d/.99-dotfiles-hardening.XXXXXX)
+    sudo tee "$tmp" > /dev/null <<EOF
     # Managed by anotherdot dotfiles (justfile harden-sshd recipe).
     PasswordAuthentication no
     PermitRootLogin prohibit-password
     EOF
-    sudo sshd -t
-    sudo systemctl reload sshd 2>/dev/null || sudo systemctl restart sshd
+    if ! sudo sshd -t; then
+        echo "harden-sshd: sshd -t failed; rolling back tempfile." >&2
+        sudo rm -f "$tmp"
+        exit 1
+    fi
+    sudo mv "$tmp" "$drop"
+    sudo systemctl reload sshd 2>/dev/null || {
+        echo "harden-sshd: reload failed, restarting sshd — active ssh sessions may drop" >&2
+        sudo systemctl restart sshd
+    }
     echo "harden-sshd: wrote $drop, sshd reloaded"
 
 # First-time setup: preflight + install deps + deploy
 bootstrap type="base": (_preflight type) (install-deps type) (deploy type)
     @echo ''
+    @echo 'Priming sudo cache (you may be prompted once)...'
+    @sudo -v
     @echo 'Setting login shell to zsh...'
     @sudo chsh -s "$(command -v zsh)" "$USER"
+    @echo 'Refreshing sudo cache after long-running install-deps...'
+    @sudo -v
     @echo 'Enabling udisks2 (system service that udiskie listens to for automount)...'
     @sudo systemctl enable --now udisks2
     @just enable-tty-autologin

--- a/justfile
+++ b/justfile
@@ -329,56 +329,6 @@ harden-sshd:
     }
     echo "harden-sshd: wrote $drop, sshd reloaded"
 
-# Diagnose hyprpaper not displaying wallpaper. Run on the affected host.
-# Read-only; no system modifications. Save with redirect for sharing:
-#   just diagnose-hyprpaper > /tmp/hyprpaper-diag.txt 2>&1
-diagnose-hyprpaper:
-    #!/usr/bin/env bash
-    set +e
-    echo "=== hyprpaper version ==="
-    yay -Qi hyprpaper 2>/dev/null | grep -E '^(Name|Version)' || echo "not installed"
-    echo
-    echo "=== config file (~/.config/hypr/hyprpaper.conf) ==="
-    if [ -L ~/.config/hypr/hyprpaper.conf ]; then
-        echo "symlink → $(readlink -f ~/.config/hypr/hyprpaper.conf)"
-    elif [ -f ~/.config/hypr/hyprpaper.conf ]; then
-        echo "regular file"
-    else
-        echo "MISSING"
-    fi
-    cat ~/.config/hypr/hyprpaper.conf 2>/dev/null
-    echo
-    echo "=== wallpaper file resolution ==="
-    echo "\$HOME = $HOME"
-    echo "expanded path = $HOME/.config/backgrounds/Gemini_Generated_Image_hsu92jhsu92jhsu9.png"
-    ls -lL "$HOME/.config/backgrounds/" 2>&1 | head -10
-    echo
-    echo "=== exec-once chain processes (the smoking gun) ==="
-    echo "If any of these are missing, the hyprland.conf:59 chain failed somewhere."
-    for proc in waybar wofi hypridle hyprpaper udiskie hyprlock; do
-        if pgrep -x "$proc" >/dev/null 2>&1; then
-            echo "  RUNNING:  $proc ($(pgrep -x $proc | tr '\n' ',' | sed 's/,$//'))"
-        else
-            echo "  MISSING:  $proc"
-        fi
-    done
-    echo
-    echo "=== host.conf symlink target (desktop vs laptop variant) ==="
-    if [ -L ~/.config/hypr/host.conf ]; then
-        echo "→ $(readlink -f ~/.config/hypr/host.conf)"
-    else
-        echo "NOT A SYMLINK or MISSING"
-    fi
-    echo
-    echo "=== hyprctl hyprpaper state ==="
-    hyprctl hyprpaper listactive 2>&1
-    echo
-    echo "=== connected monitors ==="
-    hyprctl monitors 2>&1 | grep -E '^(Monitor|	description)' | head -20
-    echo
-    echo "=== journal: 'paper' lines (last 10 minutes) ==="
-    journalctl --user --since "10 minutes ago" 2>/dev/null | grep -i paper | tail -50
-
 # First-time setup. Runs preflight → install-deps → deploy, then
 # system-level activation: chsh to zsh, enable udisks2, configure TTY1
 # autologin (no-DM hosts), harden sshd (if active). sudo cache is primed

--- a/justfile
+++ b/justfile
@@ -266,12 +266,13 @@ deploy type="base": (_preflight type)
 # First-time setup: preflight + install deps + deploy
 bootstrap type="base": (_preflight type) (install-deps type) (deploy type)
     @echo ''
+    @echo 'Setting login shell to zsh...'
+    @sudo chsh -s "$(command -v zsh)" "$USER"
     @echo 'Enabling udisks2 (system service that udiskie listens to for automount)...'
     @sudo systemctl enable --now udisks2
     @echo ''
     @echo 'Bootstrap complete. Manual steps remaining:'
-    @echo '  1. chsh -s $(which zsh)     # set zsh as default login shell'
-    @echo '  2. Reload Hyprland (Super+Shift+C) to apply config'
-    @echo '  3. Log out and back in once for GTK theme to fully apply'
-    @echo '  4. Open a new shell so .zshrc loads (dots alias becomes available)'
-    @echo '  5. (production|all only) launch firefox once from Hyprland, then `just firefox-deploy` to install userChrome'
+    @echo '  1. Reload Hyprland (Super+Shift+C) to apply config'
+    @echo '  2. Log out and back in once — for GTK theme to fully apply AND for the new zsh login shell to take effect'
+    @echo '  3. Open a new shell so .zshrc loads (dots alias becomes available)'
+    @echo '  4. (production|all only) launch firefox once from Hyprland, then `just firefox-deploy` to install userChrome'

--- a/justfile
+++ b/justfile
@@ -120,7 +120,7 @@ _pkgs_base := "hyprland hyprlock hypridle hyprpaper xdg-desktop-portal-hyprland 
               "pipewire wireplumber pavucontrol libnotify " + \
               "kitty wezterm-git neovim zsh starship " + \
               "brightnessctl playerctl hyprshot " + \
-              "jq curl " + \
+              "eza jq curl " + \
               "adw-gtk-theme ttf-firacode-nerd " + \
               "stow just git " + \
               "udiskie exfatprogs"

--- a/justfile
+++ b/justfile
@@ -111,8 +111,9 @@ restow package:
 
 # ── Bootstrap ────────────────────────────────────────────────────
 
-# git/stow/just/yay must be installed manually before `just bootstrap` can
-# start (see _preflight). They're listed here so subsequent runs keep them
+# git/just/yay must be installed manually before `just bootstrap` can
+# start (see _preflight). stow is pulled in by install-deps. These
+# tools are also listed in _pkgs_base so subsequent runs keep them
 # updated via yay -S --needed.
 # Package bundles per type. Add new packages here.
 _pkgs_base := "hyprland hyprlock hypridle hyprpaper xdg-desktop-portal-hyprland " + \
@@ -328,7 +329,10 @@ harden-sshd:
     }
     echo "harden-sshd: wrote $drop, sshd reloaded"
 
-# First-time setup: preflight + install deps + deploy
+# First-time setup. Runs preflight → install-deps → deploy, then
+# system-level activation: chsh to zsh, enable udisks2, configure TTY1
+# autologin (no-DM hosts), harden sshd (if active). sudo cache is primed
+# at start and refreshed after install-deps to minimize prompts.
 bootstrap type="base": (_preflight type) (install-deps type) (deploy type)
     @echo ''
     @echo 'Priming sudo cache (you may be prompted once)...'
@@ -342,6 +346,14 @@ bootstrap type="base": (_preflight type) (install-deps type) (deploy type)
     @just enable-tty-autologin
     @just harden-sshd
     @echo ''
-    @echo 'Bootstrap complete. Manual steps remaining:'
-    @echo '  1. Restart your session (log out + back in, or reboot) to apply configs — login shell, Hyprland, GTK theme, .zshrc env'
+    @echo 'Bootstrap complete.'
+    @echo ''
+    @echo 'Behavior changes that take effect on next session/reboot:'
+    @echo '  - login shell is now zsh (active on next login)'
+    @echo '  - on no-DM hosts: TTY1 auto-logs you in and Hyprland starts at boot'
+    @echo '  - if sshd was active: password auth and root password login are now disabled'
+    @echo '  - udisks2 is enabled (udiskie automount tray works)'
+    @echo ''
+    @echo 'Manual steps remaining:'
+    @echo '  1. Restart your session (log out + back in, or reboot) to apply all configs'
     @echo '  2. (production|all only) launch firefox once from Hyprland, then `just firefox-deploy` to install userChrome'

--- a/justfile
+++ b/justfile
@@ -173,8 +173,9 @@ _preflight type:
     case "{{type}}" in
         gaming|all)
             if ! grep -qE '^\[multilib\]' /etc/pacman.conf; then
-                echo "ERROR: type={{type}} needs steam, which requires the multilib repo." >&2
-                echo "Enable it: uncomment [multilib] in /etc/pacman.conf, then run 'sudo pacman -Syu'." >&2
+                echo "ERROR: the '{{type}}' bundle installs steam, which requires the multilib repo." >&2
+                echo "Enable it: uncomment [multilib] and its Include line in /etc/pacman.conf," >&2
+                echo "then refresh: 'sudo pacman -Sy'." >&2
                 exit 1
             fi
             ;;

--- a/justfile
+++ b/justfile
@@ -263,6 +263,29 @@ deploy type="base": (_preflight type)
             ;;
     esac
 
+# Enable TTY1 autologin so Hyprland can launch directly via ~/.zlogin
+# without a TTY login prompt. Skipped if a display manager is already
+# enabled (sddm/gdm/greetd/ly/lightdm) — DM handles the boot path and
+# autologin would race with it.
+enable-tty-autologin:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if systemctl list-unit-files --state=enabled 2>/dev/null \
+        | grep -iqE '^(sddm|gdm|greetd|ly|lightdm)\.service'; then
+        echo "enable-tty-autologin: display manager is enabled, skipping autologin override."
+        exit 0
+    fi
+    override_dir=/etc/systemd/system/getty@tty1.service.d
+    override_file="$override_dir/autologin.conf"
+    sudo mkdir -p "$override_dir"
+    sudo tee "$override_file" > /dev/null <<EOF
+    [Service]
+    ExecStart=
+    ExecStart=-/usr/bin/agetty --autologin $USER --noclear %I \$TERM
+    EOF
+    sudo systemctl daemon-reload
+    echo "enable-tty-autologin: wrote $override_file"
+
 # First-time setup: preflight + install deps + deploy
 bootstrap type="base": (_preflight type) (install-deps type) (deploy type)
     @echo ''
@@ -270,6 +293,7 @@ bootstrap type="base": (_preflight type) (install-deps type) (deploy type)
     @sudo chsh -s "$(command -v zsh)" "$USER"
     @echo 'Enabling udisks2 (system service that udiskie listens to for automount)...'
     @sudo systemctl enable --now udisks2
+    @just enable-tty-autologin
     @echo ''
     @echo 'Bootstrap complete. Manual steps remaining:'
     @echo '  1. Restart your session (log out + back in, or reboot) to apply configs — login shell, Hyprland, GTK theme, .zshrc env'

--- a/justfile
+++ b/justfile
@@ -143,11 +143,15 @@ _preflight type:
     #!/usr/bin/env bash
     set -euo pipefail
     case "{{type}}" in
+        type=*)
+            echo "ERROR: 'type=...' is just's variable-override syntax, not a recipe argument." >&2
+            echo "Use positional form: just bootstrap <base|production|gaming|all>" >&2
+            exit 1;;
         base|production|gaming|all) ;;
         *) echo "ERROR: unknown type: {{type}}. Valid: base, production, gaming, all" >&2; exit 1;;
     esac
     missing=()
-    for cmd in yay git stow; do
+    for cmd in yay git; do
         command -v "$cmd" >/dev/null 2>&1 || missing+=("$cmd")
     done
     case "{{type}}" in
@@ -157,7 +161,9 @@ _preflight type:
     esac
     if [ "${#missing[@]}" -ne 0 ]; then
         echo "ERROR: required commands missing: ${missing[*]}" >&2
-        echo "On Arch: 'sudo pacman -S --needed git base-devel stow curl', then build yay+just from AUR." >&2
+        echo "Prerequisites (per README): git, just, yay. For production|all also: curl." >&2
+        echo "yay itself is built from AUR and needs git + base-devel; once yay is in place" >&2
+        echo "it can install everything else, including stow (pulled in by 'just install-deps')." >&2
         exit 1
     fi
     if [ ! -f "{{dotfiles}}/justfile" ]; then

--- a/justfile
+++ b/justfile
@@ -266,10 +266,12 @@ deploy type="base": (_preflight type)
 # First-time setup: preflight + install deps + deploy
 bootstrap type="base": (_preflight type) (install-deps type) (deploy type)
     @echo ''
+    @echo 'Enabling udisks2 (system service that udiskie listens to for automount)...'
+    @sudo systemctl enable --now udisks2
+    @echo ''
     @echo 'Bootstrap complete. Manual steps remaining:'
     @echo '  1. chsh -s $(which zsh)     # set zsh as default login shell'
     @echo '  2. Reload Hyprland (Super+Shift+C) to apply config'
     @echo '  3. Log out and back in once for GTK theme to fully apply'
     @echo '  4. Open a new shell so .zshrc loads (dots alias becomes available)'
-    @echo '  5. sudo systemctl enable --now udisks2     # enable removable-media automount for udiskie'
-    @echo '  6. (production|all only) launch firefox once from Hyprland, then `just firefox-deploy` to install userChrome'
+    @echo '  5. (production|all only) launch firefox once from Hyprland, then `just firefox-deploy` to install userChrome'

--- a/zsh/.zlogin
+++ b/zsh/.zlogin
@@ -1,0 +1,16 @@
+#
+# ~/.zlogin — sourced by zsh on login shells, after .zshrc
+#
+
+# Auto-launch Hyprland on TTY1 login. Restores the equivalent block from
+# ~/.bash_profile, which became orphaned when the dotfiles bootstrap
+# switched the login shell from bash to zsh (justfile chsh step). Gated
+# on /dev/tty1 so it never fires in DM-launched sessions (pts), ssh
+# sessions (pts), or other TTYs.
+if [[ "$(tty)" == "/dev/tty1" ]]; then
+    if command -v start-hyprland >/dev/null 2>&1; then
+        exec start-hyprland
+    elif command -v Hyprland >/dev/null 2>&1; then
+        exec Hyprland
+    fi
+fi

--- a/zsh/.zlogin
+++ b/zsh/.zlogin
@@ -7,10 +7,20 @@
 # switched the login shell from bash to zsh (justfile chsh step). Gated
 # on /dev/tty1 so it never fires in DM-launched sessions (pts), ssh
 # sessions (pts), or other TTYs.
+#
+# If Hyprland exits (crash, manual logout), don't leave an autologged-in
+# shell exposed on TTY1 — lock the VT with vlock; password required to
+# release. Other TTYs stay reachable via Ctrl+Alt+F2..F6 for recovery.
 if [[ "$(tty)" == "/dev/tty1" ]]; then
     if command -v start-hyprland >/dev/null 2>&1; then
-        exec start-hyprland
+        start-hyprland
     elif command -v Hyprland >/dev/null 2>&1; then
-        exec Hyprland
+        Hyprland
     fi
+    if command -v vlock >/dev/null 2>&1; then
+        exec vlock
+    fi
+    # Last-resort fallback: terminate the shell so getty re-runs autologin
+    # instead of leaving an interactive prompt behind.
+    exit
 fi

--- a/zsh/.zlogin
+++ b/zsh/.zlogin
@@ -12,6 +12,15 @@
 # shell exposed on TTY1 — lock the VT with vlock; password required to
 # release. Other TTYs stay reachable via Ctrl+Alt+F2..F6 for recovery.
 if [[ "$(tty)" == "/dev/tty1" ]]; then
+    # Per-session re-entry guard: if .zlogin is somehow re-sourced in the
+    # same login session (pathological — shouldn't happen normally), drop
+    # to a recovery shell rather than risking a tight autologin loop.
+    if [[ -n "$HYPRLAND_LAUNCH_GUARD" ]]; then
+        echo "Hyprland exited twice in this autologin cycle; dropping to shell for recovery."
+        unset HYPRLAND_LAUNCH_GUARD
+        return
+    fi
+    export HYPRLAND_LAUNCH_GUARD=1
     if command -v start-hyprland >/dev/null 2>&1; then
         start-hyprland
     elif command -v Hyprland >/dev/null 2>&1; then
@@ -20,7 +29,9 @@ if [[ "$(tty)" == "/dev/tty1" ]]; then
     if command -v vlock >/dev/null 2>&1; then
         exec vlock
     fi
-    # Last-resort fallback: terminate the shell so getty re-runs autologin
-    # instead of leaving an interactive prompt behind.
+    # Last-resort fallback: brief sleep avoids a tight loop if both
+    # Hyprland and vlock are missing, then exit so getty re-runs
+    # autologin (next cycle will start with a fresh env, no guard).
+    sleep 2
     exit
 fi

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -144,8 +144,10 @@ alias news="arch-update -n"
 # Pyenv setup
 export PYENV_ROOT="$HOME/.pyenv"
 [[ -d $PYENV_ROOT/bin ]] && export PATH="$PYENV_ROOT/bin:$PATH"
-eval "$(pyenv init - zsh)"
-eval "$(pyenv virtualenv-init -)"
+if command -v pyenv >/dev/null 2>&1; then
+    eval "$(pyenv init - zsh)"
+    eval "$(pyenv virtualenv-init -)"
+fi
 
 # Nvm
 # export NVM_DIR="$HOME/.nvm"
@@ -158,11 +160,11 @@ export MANPAGER="less -R --use-color -Dd+r -Du+b"
 
 # Fix profile sourcing
 # Fix for unreliable profile sourcing, eg. switching to a second TTY
-if [[ -z "$PROFILE_SOURCED" ]]; then
+if [[ -z "$PROFILE_SOURCED" && -f ~/.zprofile ]]; then
     source ~/.zprofile
 fi
 
 # starship
 eval "$(starship init zsh)"
 
-source /usr/share/nvm/init-nvm.sh
+[[ -f /usr/share/nvm/init-nvm.sh ]] && source /usr/share/nvm/init-nvm.sh


### PR DESCRIPTION
this ended up being  a full test of the bootstrap on a new machine. given a default arch/hypr build, the goal is for bootstrap to stand up the machine quickly.

there still is some noise here. nvim is failing because i don't think python env is being set so it can load the packages it needs. will probably work that out of another branch since this pr is getting out of hand.